### PR TITLE
Run doctests in CI too

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Run cargo nextest
         run: cargo nextest run
+      - name: Run doc tests
+        run: cargo test --doc
 
   fmt:
     name: Rustfmt


### PR DESCRIPTION
cargo-nextest doesn't support them yet so we need to
run them separately.
