### PR TITLE
Don't hardcode 95% CI ppf in NaiveTrend prediction intervals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ augurs-ets = { path = "crates/augurs-ets" }
 augurs-mstl = { path = "crates/augurs-mstl" }
 augurs-testing = { path = "crates/augurs-testing" }
 
+distrs = "0.2.1"
+
 assert_approx_eq = "1.1.0"
 criterion = "0.4.0"
 pprof = { version = "0.11.1", features = ["criterion", "frame-pointer", "prost-codec"] }

--- a/crates/augurs-ets/Cargo.toml
+++ b/crates/augurs-ets/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 augurs-core.workspace = true
 augurs-mstl = { workspace = true, optional = true }
-distrs = "0.2.0"
+distrs.workspace = true
 itertools = "0.10.5"
 lstsq = "0.5.0"
 nalgebra = "0.32.2"

--- a/crates/augurs-mstl/Cargo.toml
+++ b/crates/augurs-mstl/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 
 [dependencies]
 augurs-core.workspace = true
+distrs.workspace = true
 serde = { version = "1.0.130", features = ["derive"], optional = true }
 stlrs = { git = "https://github.com/sd2k/stl-rust", branch = "python-lib", version = "0.2.1" }
 thiserror = "1.0.39"

--- a/crates/augurs-mstl/src/trend.rs
+++ b/crates/augurs-mstl/src/trend.rs
@@ -118,10 +118,7 @@ impl NaiveTrend {
         level: f64,
         sigma: impl Iterator<Item = f64>,
     ) -> ForecastIntervals {
-        // let z = distrs::Normal::ppf(0.5 + level / 2.0, 0.0, 1.0);
-        // TODO: use z-score from normal distribution rather than hardcoding
-        // 1.95999.
-        let z = 1.959964;
+        let z = distrs::Normal::ppf(0.5 + level / 2.0, 0.0, 1.0);
         let (lower, upper) = preds
             .zip(sigma)
             .map(|(p, s)| (p - z * s, p + z * s))


### PR DESCRIPTION
Closes #6.
