### PR TITLE
Use upstream `stlrs` crate

### DIFF
--- a/crates/augurs-mstl/Cargo.toml
+++ b/crates/augurs-mstl/Cargo.toml
@@ -12,7 +12,8 @@ description = "Multiple Seasonal-Trend decomposition with LOESS (MSTL) using the
 augurs-core.workspace = true
 distrs.workspace = true
 serde = { workspace = true, features = ["derive"], optional = true }
-stlrs = { git = "https://github.com/sd2k/stl-rust", branch = "python-lib", version = "0.2.1" }
+stlrs = { git = "https://github.com/ankane/stl-rust", version = "0.2.2" }
+# stlrs = "0.2.2"
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/crates/augurs-mstl/Cargo.toml
+++ b/crates/augurs-mstl/Cargo.toml
@@ -12,7 +12,7 @@ description = "Multiple Seasonal-Trend decomposition with LOESS (MSTL) using the
 augurs-core.workspace = true
 distrs.workspace = true
 serde = { workspace = true, features = ["derive"], optional = true }
-stlrs = { git = "https://github.com/ankane/stl-rust", version = "0.2.2" }
+stlrs = { git = "https://github.com/sd2k/stl-rust", branch = "mstl-debug-clone", version = "0.2.2" }
 # stlrs = "0.2.2"
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/augurs-mstl/Cargo.toml
+++ b/crates/augurs-mstl/Cargo.toml
@@ -12,8 +12,7 @@ description = "Multiple Seasonal-Trend decomposition with LOESS (MSTL) using the
 augurs-core.workspace = true
 distrs.workspace = true
 serde = { workspace = true, features = ["derive"], optional = true }
-stlrs = { git = "https://github.com/sd2k/stl-rust", branch = "mstl-debug-clone", version = "0.2.2" }
-# stlrs = "0.2.2"
+stlrs = "0.3.0"
 thiserror.workspace = true
 tracing.workspace = true
 

--- a/crates/augurs-mstl/benches/vic_elec.rs
+++ b/crates/augurs-mstl/benches/vic_elec.rs
@@ -16,12 +16,14 @@ fn vic_elec(c: &mut Criterion) {
         .low_pass_degree(1)
         .inner_loops(2)
         .outer_loops(0);
+    let mut mstl_params = stlrs::MstlParams::new();
+    mstl_params.stl_params(stl_params);
     c.bench_function("vic_elec", |b| {
         b.iter_batched(
-            || (y.clone(), vec![24, 24 * 7], stl_params.clone()),
+            || (y.clone(), vec![24, 24 * 7], mstl_params.clone()),
             |(y, periods, stl_params)| {
                 MSTLModel::new(periods, NaiveTrend::new())
-                    .stl_params(stl_params)
+                    .mstl_params(stl_params)
                     .fit(&y)
             },
             BatchSize::SmallInput,

--- a/crates/augurs-mstl/benches/vic_elec_iai.rs
+++ b/crates/augurs-mstl/benches/vic_elec_iai.rs
@@ -3,9 +3,9 @@ use iai::{black_box, main};
 use augurs_mstl::{MSTLModel, NaiveTrend};
 use augurs_testing::data::VIC_ELEC;
 
-fn vic_elec_fit(y: Vec<f64>, periods: Vec<usize>, params: stlrs::StlParams) {
+fn vic_elec_fit(y: Vec<f64>, periods: Vec<usize>, params: stlrs::MstlParams) {
     MSTLModel::new(periods, NaiveTrend::new())
-        .stl_params(params)
+        .mstl_params(params)
         .fit(&y)
         .ok();
 }
@@ -22,10 +22,12 @@ fn bench_vic_elec_fit() {
         .low_pass_degree(1)
         .inner_loops(2)
         .outer_loops(0);
+    let mut mstl_params = stlrs::MstlParams::new();
+    mstl_params.stl_params(stl_params);
     vic_elec_fit(
         black_box(y.clone()),
         black_box(vec![24, 24 * 7]),
-        black_box(stl_params),
+        black_box(mstl_params),
     );
 }
 


### PR DESCRIPTION
This mainly just means we have to cast things between f32 and f64, because the released version of stl-rs doesn't include f64 compatibility (see https://github.com/ankane/stl-rust/pull/6 and https://github.com/ankane/stl-rust/pull/2).

Note that this still currently points towards a fork of stl-rs, but at least all the incorporated changes are more likely to be merged and released soon, at which point this can be updated to use a non-git dependency.

Unfortunately this results in some benchmark regressions compared to using a fork, probably due to the extra clones and having to convert to/from f32 :(

```
     Running benches/vic_elec.rs (target/release/deps/vic_elec-36a0fad3091799a8)
vic_elec                time:   [28.569 ms 28.591 ms 28.619 ms]
                        change: [+11.550% +11.750% +11.918%] (p = 0.00 < 0.05)
                        Performance has regressed.
Found 8 outliers among 100 measurements (8.00%)
  3 (3.00%) high mild
  5 (5.00%) high severe
```