### PR TITLE
chore: don't publish binding crates; rename augurs-js to augurs

### DIFF
--- a/crates/augurs-js/Cargo.toml
+++ b/crates/augurs-js/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "augurs-js"
+name = "augurs"
 version.workspace = true
 authors.workspace = true
 documentation.workspace = true
@@ -8,6 +8,7 @@ license.workspace = true
 edition.workspace = true
 keywords.workspace = true
 description = "JavaScript bindings for the augurs time series library."
+publish = false
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/crates/pyaugurs/Cargo.toml
+++ b/crates/pyaugurs/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 edition.workspace = true
 keywords.workspace = true
 description = "Python bindings for the augurs time series library."
+publish = false
 
 [lib]
 name = "augurs"


### PR DESCRIPTION
This rename is unfortunate, but wasm-pack always uses the package
name rather than the lib name so we can't just set lib.name = augurs :(
