### PR TITLE
chore: mark tracing-wasm feature as optional; exclude by default

### DIFF
--- a/crates/augurs-js/Cargo.toml
+++ b/crates/augurs-js/Cargo.toml
@@ -28,5 +28,5 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 getrandom = { version = "0.2.10", features = ["js"] }
 js-sys = "0.3.64"
 serde-wasm-bindgen = "0.6.0"
-tracing-wasm = "0.2.1"
+tracing-wasm = { version = "0.2.1", optional = true }
 wasm-bindgen = "0.2.87"

--- a/crates/augurs-js/src/lib.rs
+++ b/crates/augurs-js/src/lib.rs
@@ -21,5 +21,6 @@ pub mod mstl;
 pub fn custom_init() {
     #[cfg(feature = "console_error_panic_hook")]
     console_error_panic_hook::set_once();
+    #[cfg(feature = "tracing-wasm")]
     tracing_wasm::try_set_as_global_default().ok();
 }


### PR DESCRIPTION
It inflates the size of the WASM bundle by 50kb, and there's not much
logging going on right now anyway...
