### PR TITLE
Use `tsify` to avoid `JsValue`/`any` types

### DIFF
--- a/crates/augurs-js/Cargo.toml
+++ b/crates/augurs-js/Cargo.toml
@@ -17,9 +17,9 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook"]
 
 [dependencies]
-augurs-core = { workspace = true, features = ["serde"] }
-augurs-ets = { workspace = true, features = ["mstl", "serde"] }
-augurs-mstl = { workspace = true, features = ["serde"] }
+augurs-core = { workspace = true }
+augurs-ets = { workspace = true, features = ["mstl"] }
+augurs-mstl = { workspace = true }
 augurs-seasons = { workspace = true }
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires
@@ -31,4 +31,5 @@ js-sys = "0.3.64"
 serde.workspace = true
 serde-wasm-bindgen = "0.6.0"
 tracing-wasm = { version = "0.2.1", optional = true }
+tsify = { version = "0.4.5", default_features = false, features = ["js"] }
 wasm-bindgen = "0.2.87"

--- a/crates/augurs-js/src/ets.rs
+++ b/crates/augurs-js/src/ets.rs
@@ -3,6 +3,8 @@
 use js_sys::Float64Array;
 use wasm_bindgen::prelude::*;
 
+use crate::Forecast;
+
 /// Automatic ETS model selection.
 #[derive(Debug)]
 #[wasm_bindgen]
@@ -48,12 +50,12 @@ impl AutoETS {
     /// # Errors
     ///
     /// This function will return an error if no model has been fit yet (using [`AutoETS::fit`]).
-    pub fn predict(&self, horizon: usize, level: Option<f64>) -> Result<JsValue, JsValue> {
-        let forecasts = self
+    #[wasm_bindgen]
+    pub fn predict(&self, horizon: usize, level: Option<f64>) -> Result<Forecast, JsValue> {
+        Ok(self
             .inner
             .predict(horizon, level)
-            .map_err(|e| e.to_string())?;
-        Ok(serde_wasm_bindgen::to_value(&forecasts)
-            .map_err(|e| format!("serializing forecasts: {e}"))?)
+            .map(Into::into)
+            .map_err(|e| e.to_string())?)
     }
 }

--- a/crates/augurs-js/src/lib.rs
+++ b/crates/augurs-js/src/lib.rs
@@ -6,6 +6,8 @@
     unreachable_pub
 )]
 
+use serde::Serialize;
+use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
 pub mod ets;
@@ -24,4 +26,49 @@ pub fn custom_init() {
     console_error_panic_hook::set_once();
     #[cfg(feature = "tracing-wasm")]
     tracing_wasm::try_set_as_global_default().ok();
+}
+
+// Wrapper types for the core types, so we can derive `Tsify` for them.
+// This avoids having to worry about `tsify` in the `augurs-core` crate.
+
+/// Forecast intervals.
+#[derive(Clone, Debug, Serialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct ForecastIntervals {
+    /// The confidence level for the intervals.
+    pub level: f64,
+    /// The lower prediction intervals.
+    pub lower: Vec<f64>,
+    /// The upper prediction intervals.
+    pub upper: Vec<f64>,
+}
+
+impl From<augurs_core::ForecastIntervals> for ForecastIntervals {
+    fn from(f: augurs_core::ForecastIntervals) -> Self {
+        Self {
+            level: f.level,
+            lower: f.lower,
+            upper: f.upper,
+        }
+    }
+}
+
+/// A forecast containing point forecasts and, optionally, prediction intervals.
+#[derive(Clone, Debug, Serialize, Tsify)]
+#[tsify(into_wasm_abi)]
+pub struct Forecast {
+    /// The point forecasts.
+    pub point: Vec<f64>,
+    /// The forecast intervals, if requested and supported
+    /// by the trend model.
+    pub intervals: Option<ForecastIntervals>,
+}
+
+impl From<augurs_core::Forecast> for Forecast {
+    fn from(f: augurs_core::Forecast) -> Self {
+        Self {
+            point: f.point,
+            intervals: f.intervals.map(Into::into),
+        }
+    }
 }

--- a/crates/augurs-js/src/mstl.rs
+++ b/crates/augurs-js/src/mstl.rs
@@ -5,6 +5,8 @@ use wasm_bindgen::prelude::*;
 use augurs_ets::AutoETS;
 use augurs_mstl::{Fit, MSTLModel, TrendModel, Unfit};
 
+use crate::Forecast;
+
 #[derive(Debug)]
 enum MSTLEnum<T> {
     Unfit(MSTLModel<T, Unfit>),
@@ -37,12 +39,12 @@ impl MSTL {
     ///
     /// If provided, `level` must be a float between 0 and 1.
     #[wasm_bindgen]
-    pub fn predict(&self, horizon: usize, level: Option<f64>) -> Result<JsValue, JsValue> {
+    pub fn predict(&self, horizon: usize, level: Option<f64>) -> Result<Forecast, JsValue> {
         match &self.inner {
-            Some(MSTLEnum::Fit(inner)) => {
-                let preds = inner.predict(horizon, level).map_err(|e| e.to_string())?;
-                Ok(serde_wasm_bindgen::to_value(&preds)?)
-            }
+            Some(MSTLEnum::Fit(inner)) => Ok(inner
+                .predict(horizon, level)
+                .map(Into::into)
+                .map_err(|e| e.to_string())?),
             _ => Err(JsValue::from_str("model is not fit")),
         }
     }
@@ -52,12 +54,12 @@ impl MSTL {
     ///
     /// If provided, `level` must be a float between 0 and 1.
     #[wasm_bindgen]
-    pub fn predict_in_sample(&self, level: Option<f64>) -> Result<JsValue, JsValue> {
+    pub fn predict_in_sample(&self, level: Option<f64>) -> Result<Forecast, JsValue> {
         match &self.inner {
-            Some(MSTLEnum::Fit(inner)) => {
-                let preds = inner.predict_in_sample(level).map_err(|e| e.to_string())?;
-                Ok(serde_wasm_bindgen::to_value(&preds)?)
-            }
+            Some(MSTLEnum::Fit(inner)) => Ok(inner
+                .predict_in_sample(level)
+                .map(Into::into)
+                .map_err(|e| e.to_string())?),
             _ => Err(JsValue::from_str("model is not fit")),
         }
     }

--- a/crates/augurs-js/src/seasons.rs
+++ b/crates/augurs-js/src/seasons.rs
@@ -1,12 +1,14 @@
 //! Javascript bindings for augurs seasonality detection.
 
 use serde::Deserialize;
+use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
 use augurs_seasons::{Detector, PeriodogramDetector};
 
 /// Options for detecting seasonal periods.
-#[derive(Debug, Default, Deserialize)]
+#[derive(Debug, Default, Deserialize, Tsify)]
+#[tsify(from_wasm_abi)]
 pub struct SeasonalityOptions {
     /// The minimum period to consider when detecting seasonal periods.
     ///
@@ -44,11 +46,6 @@ impl From<SeasonalityOptions> for PeriodogramDetector {
 
 /// Detect the seasonal periods in a time series.
 #[wasm_bindgen]
-pub fn seasonalities(y: &[f64], options: JsValue) -> Vec<u32> {
-    let options: SeasonalityOptions =
-        serde_wasm_bindgen::from_value::<Option<SeasonalityOptions>>(options)
-            .ok()
-            .flatten()
-            .unwrap_or_default();
-    PeriodogramDetector::from(options).detect(y)
+pub fn seasonalities(y: &[f64], options: Option<SeasonalityOptions>) -> Vec<u32> {
+    PeriodogramDetector::from(options.unwrap_or_default()).detect(y)
 }


### PR DESCRIPTION
Prior to this commit, the JS binding functions returned untyped `JsValue`s,
which meant the generated TypeScript types for the functions had `any`
as the return value.

This commit uses the `tsify` crate to derive the correct traits for
types returned from WASM, so that our functions can return those types
and the TypeScript definitions reflect that.
