### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 documentation = "https://docs.rs/crate/augurs"
 repository = "https://github.com/grafana/augurs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 keywords = [
   "analysis",
@@ -21,11 +21,11 @@ keywords = [
 
 [workspace.dependencies]
 
-augurs-core = { version = "0.1.1", path = "crates/augurs-core" }
-augurs-ets = { version = "0.1.1", path = "crates/augurs-ets" }
-augurs-mstl = { version = "0.1.1", path = "crates/augurs-mstl" }
-augurs-seasons = { version = "0.1.1", path = "crates/augurs-seasons" }
-augurs-testing = { version = "0.1.1", path = "crates/augurs-testing" }
+augurs-core = { version = "0.1.2", path = "crates/augurs-core" }
+augurs-ets = { version = "0.1.2", path = "crates/augurs-ets" }
+augurs-mstl = { version = "0.1.2", path = "crates/augurs-mstl" }
+augurs-seasons = { version = "0.1.2", path = "crates/augurs-seasons" }
+augurs-testing = { version = "0.1.2", path = "crates/augurs-testing" }
 
 distrs = "0.2.1"
 itertools = "0.12.0"

--- a/crates/augurs-core/CHANGELOG.md
+++ b/crates/augurs-core/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/grafana/augurs/compare/augurs-core-v0.1.1...augurs-core-v0.1.2) - 2024-02-20
+
+### Added
+- *(core)* add interpolation iterator adaptor ([#63](https://github.com/grafana/augurs/pull/63))
+
 ## [0.1.1](https://github.com/grafana/augurs/compare/augurs-core-v0.1.0...augurs-core-v0.1.1) - 2024-02-15
 
 ### Other

--- a/crates/augurs-mstl/CHANGELOG.md
+++ b/crates/augurs-mstl/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/grafana/augurs/compare/augurs-mstl-v0.1.1...augurs-mstl-v0.1.2) - 2024-02-20
+
+### Added
+- *(core)* add interpolation iterator adaptor ([#63](https://github.com/grafana/augurs/pull/63))
+
 ## [0.1.1](https://github.com/grafana/augurs/compare/augurs-mstl-v0.1.0...augurs-mstl-v0.1.1) - 2024-02-15
 
 ### Other


### PR DESCRIPTION
## 🤖 New release
* `augurs-core`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `augurs-ets`: 0.1.1 -> 0.1.2
* `augurs-mstl`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `augurs-testing`: 0.1.1 -> 0.1.2
* `augurs-seasons`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `augurs-core`
<blockquote>

## [0.1.2](https://github.com/grafana/augurs/compare/augurs-core-v0.1.1...augurs-core-v0.1.2) - 2024-02-20

### Added
- *(core)* add interpolation iterator adaptor ([#63](https://github.com/grafana/augurs/pull/63))
</blockquote>

## `augurs-ets`
<blockquote>

## [0.1.1](https://github.com/grafana/augurs/compare/augurs-ets-v0.1.0...augurs-ets-v0.1.1) - 2024-02-15

### Other
- fix clippy lint for unneeded vec macro ([#53](https://github.com/grafana/augurs/pull/53))
- Add license files to repo root and symlinks in crate directories ([#43](https://github.com/grafana/augurs/pull/43))
- Add repository to sub-crate Cargo.tomls ([#42](https://github.com/grafana/augurs/pull/42))
</blockquote>

## `augurs-mstl`
<blockquote>

## [0.1.2](https://github.com/grafana/augurs/compare/augurs-mstl-v0.1.1...augurs-mstl-v0.1.2) - 2024-02-20

### Added
- *(core)* add interpolation iterator adaptor ([#63](https://github.com/grafana/augurs/pull/63))
</blockquote>

## `augurs-testing`
<blockquote>

## [0.1.1](https://github.com/grafana/augurs/compare/augurs-testing-v0.1.0...augurs-testing-v0.1.1) - 2024-02-15

### Other
- Add seasonality detection using periodograms, and Python/JS bindings ([#61](https://github.com/grafana/augurs/pull/61))
- Add license files to repo root and symlinks in crate directories ([#43](https://github.com/grafana/augurs/pull/43))
- Add repository to sub-crate Cargo.tomls ([#42](https://github.com/grafana/augurs/pull/42))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).