### PR TITLE
feat!: add transformations and high-level forecasting API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ keywords = [
 
 augurs-core = { version = "0.1.2", path = "crates/augurs-core" }
 augurs-ets = { version = "0.1.2", path = "crates/augurs-ets" }
+augurs-forecaster = { version = "0.1.2", path = "crates/augurs-forecaster" }
 augurs-mstl = { version = "0.1.2", path = "crates/augurs-mstl" }
 augurs-seasons = { version = "0.1.2", path = "crates/augurs-seasons" }
 augurs-testing = { path = "crates/augurs-testing" }

--- a/crates/augurs-core/src/forecast.rs
+++ b/crates/augurs-core/src/forecast.rs
@@ -1,0 +1,68 @@
+/// Forecast intervals.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ForecastIntervals {
+    /// The confidence level for the intervals.
+    pub level: f64,
+    /// The lower prediction intervals.
+    pub lower: Vec<f64>,
+    /// The upper prediction intervals.
+    pub upper: Vec<f64>,
+}
+
+impl ForecastIntervals {
+    /// Return empty forecast intervals.
+    pub fn empty(level: f64) -> ForecastIntervals {
+        Self {
+            level,
+            lower: Vec::new(),
+            upper: Vec::new(),
+        }
+    }
+
+    /// Return empty forecast intervals with the specified capacity.
+    pub fn with_capacity(level: f64, capacity: usize) -> ForecastIntervals {
+        Self {
+            level,
+            lower: Vec::with_capacity(capacity),
+            upper: Vec::with_capacity(capacity),
+        }
+    }
+}
+
+/// A forecast containing point forecasts and, optionally, prediction intervals.
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Forecast {
+    /// The point forecasts.
+    pub point: Vec<f64>,
+    /// The forecast intervals, if requested and supported
+    /// by the trend model.
+    pub intervals: Option<ForecastIntervals>,
+}
+
+impl Forecast {
+    /// Return an empty forecast.
+    pub fn empty() -> Forecast {
+        Self {
+            point: Vec::new(),
+            intervals: None,
+        }
+    }
+
+    /// Return an empty forecast with the specified capacity.
+    pub fn with_capacity(capacity: usize) -> Forecast {
+        Self {
+            point: Vec::with_capacity(capacity),
+            intervals: None,
+        }
+    }
+
+    /// Return an empty forecast with the specified capacity and level.
+    pub fn with_capacity_and_level(capacity: usize, level: f64) -> Forecast {
+        Self {
+            point: Vec::with_capacity(capacity),
+            intervals: Some(ForecastIntervals::with_capacity(level, capacity)),
+        }
+    }
+}

--- a/crates/augurs-core/src/lib.rs
+++ b/crates/augurs-core/src/lib.rs
@@ -6,38 +6,23 @@
     unreachable_pub
 )]
 
+/// Common traits and types for time series forecasting models.
+pub mod prelude {
+    pub use super::{Fit, Predict};
+    pub use crate::forecast::{Forecast, ForecastIntervals};
+}
+
+mod forecast;
 pub mod interpolate;
+mod traits;
 
-/// Forecast intervals.
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ForecastIntervals {
-    /// The confidence level for the intervals.
-    pub level: f64,
-    /// The lower prediction intervals.
-    pub lower: Vec<f64>,
-    /// The upper prediction intervals.
-    pub upper: Vec<f64>,
-}
+use std::convert::Infallible;
 
-impl ForecastIntervals {
-    /// Return empty forecast intervals.
-    pub fn empty(level: f64) -> ForecastIntervals {
-        Self {
-            level,
-            lower: Vec::new(),
-            upper: Vec::new(),
-        }
-    }
-}
+pub use forecast::{Forecast, ForecastIntervals};
+pub use traits::{Fit, Predict};
 
-/// A forecast containing point forecasts and, optionally, prediction intervals.
-#[derive(Clone, Debug)]
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Forecast {
-    /// The point forecasts.
-    pub point: Vec<f64>,
-    /// The forecast intervals, if requested and supported
-    /// by the trend model.
-    pub intervals: Option<ForecastIntervals>,
-}
+/// An error produced by a time series forecasting model.
+pub trait ModelError: std::error::Error + Sync + Send + 'static {}
+
+impl std::error::Error for Box<dyn ModelError> {}
+impl ModelError for Infallible {}

--- a/crates/augurs-core/src/traits.rs
+++ b/crates/augurs-core/src/traits.rs
@@ -1,0 +1,120 @@
+use crate::{Forecast, ModelError};
+
+/// A new, unfitted time series forecasting model.
+pub trait Fit {
+    /// The type of the fitted model produced by the `fit` method.
+    type Fitted: Predict;
+
+    /// The type of error returned when fitting the model.
+    type Error: ModelError;
+
+    /// Fit the model to the training data.
+    fn fit(&self, y: &[f64]) -> Result<Self::Fitted, Self::Error>;
+}
+
+impl<F> Fit for Box<F>
+where
+    F: Fit,
+{
+    type Fitted = F::Fitted;
+    type Error = F::Error;
+    fn fit(&self, y: &[f64]) -> Result<Self::Fitted, Self::Error> {
+        (**self).fit(y)
+    }
+}
+
+/// A fitted time series forecasting model.
+pub trait Predict {
+    /// The type of error returned when predicting with the model.
+    type Error: ModelError;
+
+    /// Calculate the in-sample predictions, storing the results in the provided
+    /// [`Forecast`] struct.
+    ///
+    /// The predictions are point forecasts and optionally include
+    /// prediction intervals at the specified `level`.
+    ///
+    /// `level` should be a float between 0 and 1 representing the
+    /// confidence level of the prediction intervals. If `None` then
+    /// no prediction intervals are returned.
+    ///
+    /// # Errors
+    ///
+    /// Any errors returned by the trend model are propagated.
+    fn predict_in_sample_inplace(
+        &self,
+        level: Option<f64>,
+        forecast: &mut Forecast,
+    ) -> Result<(), Self::Error>;
+
+    /// Calculate the n-ahead predictions for the given horizon, storing the results in the
+    /// provided [`Forecast`] struct.
+    ///
+    /// The predictions are point forecasts and optionally include
+    /// prediction intervals at the specified `level`.
+    ///
+    /// `level` should be a float between 0 and 1 representing the
+    /// confidence level of the prediction intervals. If `None` then
+    /// no prediction intervals are returned.
+    ///
+    /// # Errors
+    ///
+    /// Any errors returned by the trend model are propagated.
+    fn predict_inplace(
+        &self,
+        horizon: usize,
+        level: Option<f64>,
+        forecast: &mut Forecast,
+    ) -> Result<(), Self::Error>;
+
+    /// Return the number of training data points used to fit the model.
+    ///
+    /// This is used for pre-allocating the in-sample forecasts.
+    fn training_data_size(&self) -> usize;
+
+    /// Return the n-ahead predictions for the given horizon.
+    ///
+    /// The predictions are point forecasts and optionally include
+    /// prediction intervals at the specified `level`.
+    ///
+    /// `level` should be a float between 0 and 1 representing the
+    /// confidence level of the prediction intervals. If `None` then
+    /// no prediction intervals are returned.
+    ///
+    /// # Errors
+    ///
+    /// Any errors returned by the trend model are propagated.
+    fn predict(
+        &self,
+        horizon: usize,
+        level: impl Into<Option<f64>>,
+    ) -> Result<Forecast, Self::Error> {
+        let level = level.into();
+        let mut forecast = level
+            .map(|l| Forecast::with_capacity_and_level(horizon, l))
+            .unwrap_or_else(|| Forecast::with_capacity(horizon));
+        self.predict_inplace(horizon, level, &mut forecast)?;
+        Ok(forecast)
+    }
+
+    /// Return the in-sample predictions.
+    ///
+    /// The predictions are point forecasts and optionally include
+    /// prediction intervals at the specified `level`.
+    ///
+    /// `level` should be a float between 0 and 1 representing the
+    /// confidence level of the prediction intervals. If `None` then
+    /// no prediction intervals are returned.
+    ///
+    /// # Errors
+    ///
+    /// Any errors returned by the trend model are propagated.
+    fn predict_in_sample(&self, level: impl Into<Option<f64>>) -> Result<Forecast, Self::Error> {
+        let level = level.into();
+        let mut forecast = level
+            .map(|l| Forecast::with_capacity_and_level(self.training_data_size(), l))
+            .unwrap_or_else(|| Forecast::with_capacity(self.training_data_size()));
+        self.predict_in_sample_inplace(level, &mut forecast)?;
+        Ok(forecast)
+    }
+}

--- a/crates/augurs-ets/benches/air_passengers.rs
+++ b/crates/augurs-ets/benches/air_passengers.rs
@@ -1,6 +1,7 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use pprof::criterion::{Output, PProfProfiler};
 
+use augurs_core::{Fit, Predict};
 use augurs_ets::{
     model::{ErrorComponent, ModelType, SeasonalComponent::None, TrendComponent, Unfit},
     AutoETS,
@@ -50,7 +51,7 @@ fn forecast(c: &mut Criterion) {
     let mut group = c.benchmark_group("forecast");
     group.bench_function("air_passengers", |b| {
         b.iter(|| {
-            model.predict(24, 0.95);
+            model.predict(24, 0.95).unwrap();
         })
     });
 }

--- a/crates/augurs-ets/benches/air_passengers_iai.rs
+++ b/crates/augurs-ets/benches/air_passengers_iai.rs
@@ -1,5 +1,6 @@
 use iai::{black_box, main};
 
+use augurs_core::Fit;
 use augurs_ets::{
     model::{ErrorComponent, ModelType, SeasonalComponent::None, TrendComponent, Unfit},
     AutoETS,

--- a/crates/augurs-ets/src/lib.rs
+++ b/crates/augurs-ets/src/lib.rs
@@ -9,13 +9,14 @@
 //! # Example
 //!
 //! ```
+//! use augurs_core::prelude::*;
 //! use augurs_ets::AutoETS;
 //!
 //! let data: Vec<_> = (0..10).map(|x| x as f64).collect();
 //! let mut search = AutoETS::new(1, "ZZN")
 //!     .expect("ZZN is a valid model search specification string");
 //! let model = search.fit(&data).expect("fit should succeed");
-//! let forecast = model.predict(5, 0.95);
+//! let forecast = model.predict(5, 0.95).expect("predict should succeed");
 //! assert_eq!(forecast.point.len(), 5);
 //! assert_eq!(forecast.point, vec![10.0, 11.0, 12.0, 13.0, 14.0]);
 //! ```
@@ -29,9 +30,10 @@ mod ets;
 pub mod model;
 mod stat;
 #[cfg(feature = "mstl")]
-mod trend;
+pub mod trend;
 
-pub use auto::{AutoETS, AutoSpec};
+use augurs_core::ModelError;
+pub use auto::{AutoETS, AutoSpec, FittedAutoETS};
 
 #[cfg(test)]
 // Assert that a is within (tol * 100)% of b.
@@ -86,6 +88,8 @@ pub enum Error {
     #[error("model not fit")]
     ModelNotFit,
 }
+
+impl ModelError for Error {}
 
 type Result<T> = std::result::Result<T, Error>;
 

--- a/crates/augurs-ets/src/trend.rs
+++ b/crates/augurs-ets/src/trend.rs
@@ -1,45 +1,83 @@
+/*!
+Implementations of [`augurs_mstl::TrendModel`] using the [`AutoETS`] model.
+
+This module provides the [`AutoETSTrendModel`] type, which is a trend model
+implementation that uses the [`AutoETS`] model to fit and predict the trend
+component of the [`augurs_mstl::MSTLModel`] model.
+
+This module is gated behind the `mstl` feature.
+*/
 use std::borrow::Cow;
 
-use augurs_core::{Forecast, ForecastIntervals};
+use augurs_core::{Fit, Forecast, Predict};
 use augurs_mstl::TrendModel;
 
-use crate::AutoETS;
+use crate::{AutoETS, FittedAutoETS};
 
-impl TrendModel for AutoETS {
+/// An MSTL-compatible trend model using the [`AutoETS`] model.
+#[derive(Debug, Clone)]
+pub struct AutoETSTrendModel {
+    model: AutoETS,
+    fitted: Option<FittedAutoETS>,
+}
+
+impl From<AutoETS> for AutoETSTrendModel {
+    fn from(model: AutoETS) -> Self {
+        Self {
+            model,
+            fitted: None,
+        }
+    }
+}
+
+impl TrendModel for AutoETSTrendModel {
     fn name(&self) -> Cow<'_, str> {
         Cow::Borrowed("AutoETS")
     }
 
     fn fit(&mut self, y: &[f64]) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-        Ok(self.fit(y).map(|_| ())?)
+        match self.model.fit(y) {
+            Ok(fit) => {
+                self.fitted = Some(fit);
+                Ok(())
+            }
+            Err(e) => Err(e.into()),
+        }
     }
 
-    fn predict(
+    fn predict_inplace(
         &self,
         horizon: usize,
         level: Option<f64>,
-    ) -> Result<Forecast, Box<dyn std::error::Error + Send + Sync + 'static>> {
-        Ok(self.predict(horizon, level).map(|forecast| Forecast {
-            point: forecast.point,
-            intervals: forecast.intervals.map(|fi| ForecastIntervals {
-                level: fi.level,
-                lower: fi.lower,
-                upper: fi.upper,
-            }),
-        })?)
+        forecast: &mut Forecast,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+        self.fitted
+            .as_ref()
+            .ok_or("Model not yet fit")?
+            .predict_inplace(horizon, level, forecast)
+            .map_err(|e| e.into())
     }
 
-    fn predict_in_sample(
+    fn predict_in_sample_inplace(
         &self,
         level: Option<f64>,
-    ) -> Result<Forecast, Box<dyn std::error::Error + Send + Sync + 'static>> {
-        Ok(self.predict_in_sample(level).map(|forecast| Forecast {
-            point: forecast.point,
-            intervals: forecast.intervals.map(|fi| ForecastIntervals {
-                level: fi.level,
-                lower: fi.lower,
-                upper: fi.upper,
-            }),
-        })?)
+        forecast: &mut Forecast,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+        self.fitted
+            .as_ref()
+            .ok_or("Model not yet fit")?
+            .predict_in_sample_inplace(level, forecast)
+            .map_err(|e| e.into())
+    }
+
+    fn training_data_size(&self) -> Option<usize> {
+        self.fitted.as_ref().map(|f| f.training_data_size())
+    }
+}
+
+impl AutoETS {
+    /// Create a new `AutoETSTrendModel` using the given `AutoETS` model.
+    pub fn into_trend_model(self) -> AutoETSTrendModel {
+        self.into()
     }
 }

--- a/crates/augurs-forecaster/Cargo.toml
+++ b/crates/augurs-forecaster/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "augurs-forecaster"
+license.workspace = true
+authors.workspace = true
+documentation.workspace = true
+repository.workspace = true
+version.workspace = true
+edition.workspace = true
+keywords.workspace = true
+description = "A high-level API for the augurs forecasting library."
+
+[dependencies]
+augurs-core.workspace = true
+itertools.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+augurs-ets = { workspace = true, features = ["mstl"] }
+augurs-mstl.workspace = true
+augurs-testing.workspace = true

--- a/crates/augurs-forecaster/LICENSE-APACHE
+++ b/crates/augurs-forecaster/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/augurs-forecaster/LICENSE-MIT
+++ b/crates/augurs-forecaster/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/augurs-forecaster/README.md
+++ b/crates/augurs-forecaster/README.md
@@ -1,0 +1,56 @@
+# High level forecasting API for the augurs time series library
+
+`augurs-forecaster` contains a high-level API for training and predicting with time series models. It currently allows you to combine a model with a set of transformations (such as imputation of missing data, min-max scaling, and log/logit transforms) and fit the model on the transformed data, automatically handling back-transformation of forecasts and prediction intervals.
+
+## Usage
+
+First add this crate, `augurs-core`, and any required model crates to your `Cargo.toml`:
+
+```toml
+[dependencies]
+augurs-ets = { version = "*", features = ["mstl"] }
+augurs-forecaster = "*"
+augurs-mstl = "*"
+```
+
+```rust
+use augurs_ets::{AutoETS, trend::AutoETSTrendModel};
+use augurs_forecaster::{Forecaster, Transform, transforms::MinMaxScaleParams};
+use augurs_mstl::MSTLModel;
+
+let data = &[
+    1.0, 1.2, 1.4, 1.5, f64::NAN, 1.4, 1.2, 1.5, 1.6, 2.0, 1.9, 1.8
+];
+
+// Set up the model. We're going to use an MSTL model to handle
+// multiple seasonalities, with a non-seasonal `AutoETS` model
+// for the trend component.
+// We could also use any model that implements `augurs_core::Fit`.
+let ets = AutoETS::non_seasonal().into_trend_model();
+let mstl = MSTLModel::new(vec![2], ets);
+
+// Set up the transforms.
+let transforms = vec![
+    Transform::linear_interpolator(),
+    Transform::min_max_scaler(MinMaxScaleParams::from_data(data.iter().copied())),
+    Transform::log(),
+];
+
+// Create a forecaster using the transforms.
+let mut forecaster = Forecaster::new(mstl).with_transforms(transforms);
+
+// Fit the forecaster. This will transform the training data by
+// running the transforms in order, then fit the MSTL model.
+forecaster.fit(&data).expect("model should fit");
+
+// Generate some in-sample predictions with 95% prediction intervals.
+// The forecaster will handle back-transforming them onto our original scale.
+let in_sample = forecaster
+    .predict_in_sample(0.95)
+    .expect("in-sample predictions should work");
+
+// Similarly for out-of-sample predictions:
+let out_of_sample = forecaster
+    .predict(5, 0.95)
+    .expect("out-of-sample predictions should work");
+```

--- a/crates/augurs-forecaster/src/data.rs
+++ b/crates/augurs-forecaster/src/data.rs
@@ -1,0 +1,35 @@
+/// Trait for data that can be used in the forecaster.
+///
+/// This trait is implemented for a number of types including slices, arrays, and
+/// vectors. It is also implemented for references to these types.
+pub trait Data {
+    /// Return the data as a slice of `f64`.
+    fn as_slice(&self) -> &[f64];
+}
+
+impl<const N: usize> Data for [f64; N] {
+    fn as_slice(&self) -> &[f64] {
+        self
+    }
+}
+
+impl Data for &[f64] {
+    fn as_slice(&self) -> &[f64] {
+        self
+    }
+}
+
+impl Data for Vec<f64> {
+    fn as_slice(&self) -> &[f64] {
+        self.as_slice()
+    }
+}
+
+impl<T> Data for &T
+where
+    T: Data,
+{
+    fn as_slice(&self) -> &[f64] {
+        (*self).as_slice()
+    }
+}

--- a/crates/augurs-forecaster/src/error.rs
+++ b/crates/augurs-forecaster/src/error.rs
@@ -1,0 +1,21 @@
+use augurs_core::ModelError;
+
+/// Errors returned by this crate.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// The model has not yet been fit.
+    #[error("Model not yet fit")]
+    ModelNotYetFit,
+    /// An error occurred while fitting a model.
+    #[error("Fit error: {source}")]
+    Fit {
+        /// The original error.
+        source: Box<dyn ModelError>,
+    },
+    /// An error occurred while making predictions for a model.
+    #[error("Predict error: {source}")]
+    Predict {
+        /// The original error.
+        source: Box<dyn ModelError>,
+    },
+}

--- a/crates/augurs-forecaster/src/forecaster.rs
+++ b/crates/augurs-forecaster/src/forecaster.rs
@@ -1,0 +1,126 @@
+use augurs_core::{Fit, Forecast, ModelError, Predict};
+
+use crate::{Data, Error, Result, Transform, Transforms};
+
+/// A high-level API to fit and predict time series forecasting models.
+///
+/// The `Forecaster` type allows you to combine a model with a set of
+/// transformations and fit it to a time series, then use the fitted model to
+/// make predictions. The predictions are back-transformed using the inverse of
+/// the transformations applied to the input data.
+#[derive(Debug)]
+pub struct Forecaster<M: Fit> {
+    model: M,
+    fitted: Option<M::Fitted>,
+
+    transforms: Transforms,
+}
+
+impl<M> Forecaster<M>
+where
+    M: Fit,
+    M::Fitted: Predict,
+{
+    /// Create a new `Forecaster` with the given model.
+    pub fn new(model: M) -> Self {
+        Self {
+            model,
+            fitted: None,
+            transforms: Transforms::default(),
+        }
+    }
+
+    /// Set the transformations to be applied to the input data.
+    pub fn with_transforms(mut self, transforms: Vec<Transform>) -> Self {
+        self.transforms = Transforms::new(transforms);
+        self
+    }
+
+    /// Fit the model to the given time series.
+    pub fn fit<D: Data + Clone>(&mut self, y: D) -> Result<()> {
+        let data: Vec<_> = self
+            .transforms
+            .transform(y.as_slice().iter().copied())
+            .collect();
+        self.fitted = Some(self.model.fit(&data).map_err(|e| Error::Fit {
+            source: Box::new(e) as Box<dyn ModelError>,
+        })?);
+        Ok(())
+    }
+
+    fn fitted(&self) -> Result<&M::Fitted> {
+        self.fitted.as_ref().ok_or(Error::ModelNotYetFit)
+    }
+
+    /// Predict the next `horizon` values, optionally including prediction
+    /// intervals at the given level.
+    pub fn predict(&self, horizon: usize, level: impl Into<Option<f64>>) -> Result<Forecast> {
+        self.fitted()?
+            .predict(horizon, level.into())
+            .map_err(|e| Error::Predict {
+                source: Box::new(e) as Box<dyn ModelError>,
+            })
+            .map(|f| self.transforms.inverse_transform(f))
+    }
+
+    /// Produce in-sample forecasts, optionally including prediction intervals
+    /// at the given level.
+    pub fn predict_in_sample(&self, level: impl Into<Option<f64>>) -> Result<Forecast> {
+        self.fitted()?
+            .predict_in_sample(level.into())
+            .map_err(|e| Error::Predict {
+                source: Box::new(e) as Box<dyn ModelError>,
+            })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use itertools::{Itertools, MinMaxResult};
+
+    use augurs_mstl::{MSTLModel, NaiveTrend};
+
+    use crate::transforms::MinMaxScaleParams;
+
+    use super::*;
+
+    fn assert_approx_eq(a: f64, b: f64) -> bool {
+        if a.is_nan() && b.is_nan() {
+            return true;
+        }
+        (a - b).abs() < 0.001
+    }
+
+    fn assert_all_approx_eq(a: &[f64], b: &[f64]) {
+        if a.len() != b.len() {
+            assert_eq!(a, b);
+        }
+        for (ai, bi) in a.iter().zip(b) {
+            if !assert_approx_eq(*ai, *bi) {
+                assert_eq!(a, b);
+            }
+        }
+    }
+
+    #[test]
+    fn test_forecaster() {
+        let data = &[1.0_f64, 2.0, 3.0, 4.0, 5.0];
+        let MinMaxResult::MinMax(min, max) = data
+            .iter()
+            .copied()
+            .minmax_by(|a, b| a.partial_cmp(b).unwrap())
+        else {
+            unreachable!();
+        };
+        let transforms = vec![
+            Transform::linear_interpolator(),
+            Transform::min_max_scaler(MinMaxScaleParams::new(min - 1e-3, max + 1e-3)),
+            Transform::logit(),
+        ];
+        let model = MSTLModel::new(vec![2], NaiveTrend::new());
+        let mut forecaster = Forecaster::new(model).with_transforms(transforms);
+        forecaster.fit(data).unwrap();
+        let forecasts = forecaster.predict(4, None).unwrap();
+        assert_all_approx_eq(&forecasts.point, &[5.0, 5.0, 5.0, 5.0]);
+    }
+}

--- a/crates/augurs-forecaster/src/forecaster.rs
+++ b/crates/augurs-forecaster/src/forecaster.rs
@@ -1,4 +1,4 @@
-use augurs_core::{Fit, Forecast, ModelError, Predict};
+use augurs_core::{Fit, Forecast, Predict};
 
 use crate::{Data, Error, Result, Transform, Transforms};
 
@@ -43,7 +43,7 @@ where
             .transform(y.as_slice().iter().copied())
             .collect();
         self.fitted = Some(self.model.fit(&data).map_err(|e| Error::Fit {
-            source: Box::new(e) as Box<dyn ModelError>,
+            source: Box::new(e) as _,
         })?);
         Ok(())
     }
@@ -58,7 +58,7 @@ where
         self.fitted()?
             .predict(horizon, level.into())
             .map_err(|e| Error::Predict {
-                source: Box::new(e) as Box<dyn ModelError>,
+                source: Box::new(e) as _,
             })
             .map(|f| self.transforms.inverse_transform(f))
     }
@@ -69,7 +69,7 @@ where
         self.fitted()?
             .predict_in_sample(level.into())
             .map_err(|e| Error::Predict {
-                source: Box::new(e) as Box<dyn ModelError>,
+                source: Box::new(e) as _,
             })
     }
 }

--- a/crates/augurs-forecaster/src/lib.rs
+++ b/crates/augurs-forecaster/src/lib.rs
@@ -1,0 +1,20 @@
+#![doc = include_str!("../README.md")]
+#![warn(
+    missing_docs,
+    missing_debug_implementations,
+    rust_2018_idioms,
+    unreachable_pub
+)]
+
+mod data;
+mod error;
+mod forecaster;
+pub mod transforms;
+
+pub use data::Data;
+pub use error::Error;
+pub use forecaster::Forecaster;
+pub use transforms::Transform;
+pub(crate) use transforms::Transforms;
+
+type Result<T> = std::result::Result<T, Error>;

--- a/crates/augurs-forecaster/src/transforms.rs
+++ b/crates/augurs-forecaster/src/transforms.rs
@@ -21,9 +21,7 @@ impl Transforms {
     {
         self.0
             .iter()
-            .fold(Box::new(input) as Box<dyn Iterator<Item = f64>>, |y, t| {
-                t.transform(y)
-            })
+            .fold(Box::new(input) as _, |y, t| t.transform(y))
     }
 
     pub(crate) fn inverse_transform(&self, forecast: Forecast) -> Forecast {

--- a/crates/augurs-forecaster/src/transforms.rs
+++ b/crates/augurs-forecaster/src/transforms.rs
@@ -1,0 +1,507 @@
+/*!
+Data transformations.
+*/
+
+use augurs_core::{
+    interpolate::{InterpolateExt, LinearInterpolator},
+    Forecast,
+};
+
+#[derive(Debug, Default)]
+pub(crate) struct Transforms(Vec<Transform>);
+
+impl Transforms {
+    pub(crate) fn new(transforms: Vec<Transform>) -> Self {
+        Self(transforms)
+    }
+
+    pub(crate) fn transform<'a, T>(&'a self, input: T) -> Box<dyn Iterator<Item = f64> + '_>
+    where
+        T: Iterator<Item = f64> + 'a,
+    {
+        self.0
+            .iter()
+            .fold(Box::new(input) as Box<dyn Iterator<Item = f64>>, |y, t| {
+                t.transform(y)
+            })
+    }
+
+    pub(crate) fn inverse_transform(&self, forecast: Forecast) -> Forecast {
+        self.0
+            .iter()
+            .rev()
+            .fold(forecast, |f, t| t.inverse_transform_forecast(f))
+    }
+}
+
+/// A transformation that can be applied to a time series.
+#[derive(Debug)]
+pub enum Transform {
+    /// Linear interpolation.
+    ///
+    /// This can be used to fill in missing values in a time series
+    /// by interpolating between the nearest non-missing values.
+    LinearInterpolator,
+    /// Min-max scaling.
+    MinMaxScaler(MinMaxScaleParams),
+    /// Logit transform.
+    Logit,
+    /// Log transform.
+    Log,
+}
+
+impl Transform {
+    /// Create a new linear interpolator.
+    ///
+    /// This interpolator uses linear interpolation to fill in missing values.
+    pub fn linear_interpolator() -> Self {
+        Self::LinearInterpolator
+    }
+
+    /// Create a new min-max scaler.
+    ///
+    /// This scaler scales each item to the range [0, 1].
+    ///
+    /// Because transforms operate on iterators, the data min and max must be passed for now.
+    /// This also allows for the possibility of using different min and max values; for example,
+    /// if you know that the true possible min and max of your data differ from the sample.
+    pub fn min_max_scaler(min_max_params: MinMaxScaleParams) -> Self {
+        Self::MinMaxScaler(min_max_params)
+    }
+
+    /// Create a new logit transform.
+    ///
+    /// This transform applies the logit function to each item.
+    pub fn logit() -> Self {
+        Self::Logit
+    }
+
+    /// Create a new log transform.
+    ///
+    /// This transform applies the natural logarithm to each item.
+    pub fn log() -> Self {
+        Self::Log
+    }
+
+    pub(crate) fn transform<'a, T>(&'a self, input: T) -> Box<dyn Iterator<Item = f64> + '_>
+    where
+        T: Iterator<Item = f64> + 'a,
+    {
+        match self {
+            Self::LinearInterpolator => Box::new(input.interpolate(LinearInterpolator::default())),
+            Self::MinMaxScaler(params) => Box::new(input.min_max_scale(params.clone())),
+            Self::Logit => Box::new(input.logit()),
+            Self::Log => Box::new(input.log()),
+        }
+    }
+
+    pub(crate) fn inverse_transform<'a, T>(&'a self, input: T) -> Box<dyn Iterator<Item = f64> + '_>
+    where
+        T: Iterator<Item = f64> + 'a,
+    {
+        match self {
+            Self::LinearInterpolator => Box::new(input),
+            Self::MinMaxScaler(params) => Box::new(input.inverse_min_max_scale(params.clone())),
+            Self::Logit => Box::new(input.logistic()),
+            Self::Log => Box::new(input.exp()),
+        }
+    }
+
+    pub(crate) fn inverse_transform_forecast(&self, mut f: Forecast) -> Forecast {
+        f.point = self.inverse_transform(f.point.into_iter()).collect();
+        if let Some(mut intervals) = f.intervals.take() {
+            intervals.lower = self
+                .inverse_transform(intervals.lower.into_iter())
+                .collect();
+            intervals.upper = self
+                .inverse_transform(intervals.upper.into_iter())
+                .collect();
+            f.intervals = Some(intervals);
+        }
+        f
+    }
+}
+
+// Actual implementations of the transforms.
+// These may be moved to a separate module or crate in the future.
+
+/// A transformer that scales each item to a certain range.
+///
+/// The target range is [0, 1] by default. Use [`MinMaxScaleParams::with_scaled_range`]
+/// to set a custom range.
+#[derive(Debug, Clone)]
+pub struct MinMaxScaleParams {
+    data_min: f64,
+    data_max: f64,
+    scaled_min: f64,
+    scaled_max: f64,
+}
+
+impl MinMaxScaleParams {
+    /// Create a new `MinMaxScaleParams` with the given data min and max.
+    ///
+    /// The scaled range is set to [0, 1] by default.
+    pub fn new(data_min: f64, data_max: f64) -> Self {
+        Self {
+            data_min,
+            data_max,
+            scaled_min: 0.0 + f64::EPSILON,
+            scaled_max: 1.0 - f64::EPSILON,
+        }
+    }
+
+    /// Set the scaled range for the transformation.
+    pub fn with_scaled_range(mut self, min: f64, max: f64) -> Self {
+        self.scaled_min = min;
+        self.scaled_max = max;
+        self
+    }
+
+    /// Create a new `MinMaxScaleParams` from the given data.
+    pub fn from_data<T>(data: T) -> Self
+    where
+        T: Iterator<Item = f64>,
+    {
+        let (min, max) = data.fold((f64::INFINITY, f64::NEG_INFINITY), |(min, max), x| {
+            (min.min(x), max.max(x))
+        });
+        Self::new(min, max)
+    }
+}
+
+/// Iterator adapter that scales each item to the range [0, 1].
+#[derive(Debug, Clone)]
+struct MinMaxScale<T> {
+    inner: T,
+    params: MinMaxScaleParams,
+}
+
+impl<T> Iterator for MinMaxScale<T>
+where
+    T: Iterator<Item = f64>,
+{
+    type Item = f64;
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            params:
+                MinMaxScaleParams {
+                    data_min,
+                    data_max,
+                    scaled_min,
+                    scaled_max,
+                },
+            ..
+        } = self;
+        self.inner.next().map(|x| {
+            *scaled_min + ((x - *data_min) * (*scaled_max - *scaled_min)) / (*data_max - *data_min)
+        })
+    }
+}
+
+trait MinMaxScaleExt: Iterator<Item = f64> {
+    fn min_max_scale(self, params: MinMaxScaleParams) -> MinMaxScale<Self>
+    where
+        Self: Sized,
+    {
+        MinMaxScale {
+            inner: self,
+            params,
+        }
+    }
+}
+
+impl<T> MinMaxScaleExt for T where T: Iterator<Item = f64> {}
+
+struct InverseMinMaxScale<T> {
+    inner: T,
+    params: MinMaxScaleParams,
+}
+
+impl<T> Iterator for InverseMinMaxScale<T>
+where
+    T: Iterator<Item = f64>,
+{
+    type Item = f64;
+    fn next(&mut self) -> Option<Self::Item> {
+        let Self {
+            params:
+                MinMaxScaleParams {
+                    data_min,
+                    data_max,
+                    scaled_min,
+                    scaled_max,
+                },
+            ..
+        } = self;
+        self.inner.next().map(|x| {
+            *data_min + ((x - *scaled_min) * (*data_max - *data_min)) / (*scaled_max - *scaled_min)
+        })
+    }
+}
+
+trait InverseMinMaxScaleExt: Iterator<Item = f64> {
+    fn inverse_min_max_scale(self, params: MinMaxScaleParams) -> InverseMinMaxScale<Self>
+    where
+        Self: Sized,
+    {
+        InverseMinMaxScale {
+            inner: self,
+            params,
+        }
+    }
+}
+
+impl<T> InverseMinMaxScaleExt for T where T: Iterator<Item = f64> {}
+
+// Logit and logistic functions.
+
+/// Returns the logistic function of the given value.
+fn logistic(x: f64) -> f64 {
+    1.0 / (1.0 + (-x).exp())
+}
+
+/// Returns the logit function of the given value.
+fn logit(x: f64) -> f64 {
+    (x / (1.0 - x)).ln()
+}
+
+/// An iterator adapter that applies the logit function to each item.
+#[derive(Clone, Debug)]
+struct Logit<T> {
+    inner: T,
+}
+
+impl<T> Iterator for Logit<T>
+where
+    T: Iterator<Item = f64>,
+{
+    type Item = f64;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(logit)
+    }
+}
+
+trait LogitExt: Iterator<Item = f64> {
+    fn logit(self) -> Logit<Self>
+    where
+        Self: Sized,
+    {
+        Logit { inner: self }
+    }
+}
+
+impl<T> LogitExt for T where T: Iterator<Item = f64> {}
+
+/// An iterator adapter that applies the logistic function to each item.
+#[derive(Clone, Debug)]
+struct Logistic<T> {
+    inner: T,
+}
+
+impl<T> Iterator for Logistic<T>
+where
+    T: Iterator<Item = f64>,
+{
+    type Item = f64;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(logistic)
+    }
+}
+
+trait LogisticExt: Iterator<Item = f64> {
+    fn logistic(self) -> Logistic<Self>
+    where
+        Self: Sized,
+    {
+        Logistic { inner: self }
+    }
+}
+
+impl<T> LogisticExt for T where T: Iterator<Item = f64> {}
+
+/// An iterator adapter that applies the log function to each item.
+#[derive(Clone, Debug)]
+struct Log<T> {
+    inner: T,
+}
+
+impl<T> Iterator for Log<T>
+where
+    T: Iterator<Item = f64>,
+{
+    type Item = f64;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(f64::ln)
+    }
+}
+
+trait LogExt: Iterator<Item = f64> {
+    fn log(self) -> Log<Self>
+    where
+        Self: Sized,
+    {
+        Log { inner: self }
+    }
+}
+
+impl<T> LogExt for T where T: Iterator<Item = f64> {}
+
+/// An iterator adapter that applies the exponential function to each item.
+#[derive(Clone, Debug)]
+struct Exp<T> {
+    inner: T,
+}
+
+impl<T> Iterator for Exp<T>
+where
+    T: Iterator<Item = f64>,
+{
+    type Item = f64;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next().map(f64::exp)
+    }
+}
+
+trait ExpExt: Iterator<Item = f64> {
+    fn exp(self) -> Exp<Self>
+    where
+        Self: Sized,
+    {
+        Exp { inner: self }
+    }
+}
+
+impl<T> ExpExt for T where T: Iterator<Item = f64> {}
+
+#[cfg(test)]
+mod test {
+    use augurs_testing::{assert_all_close, assert_approx_eq};
+
+    use super::*;
+
+    #[test]
+    fn test_logistic() {
+        let x = 0.0;
+        let expected = 0.5;
+        let actual = logistic(x);
+        assert_approx_eq!(expected, actual);
+        let x = 1.0;
+        let expected = 1.0 / (1.0 + (-1.0_f64).exp());
+        let actual = logistic(x);
+        assert_approx_eq!(expected, actual);
+        let x = -1.0;
+        let expected = 1.0 / (1.0 + 1.0_f64.exp());
+        let actual = logistic(x);
+        assert_approx_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_logit() {
+        let x = 0.5;
+        let expected = 0.0;
+        let actual = logit(x);
+        assert_eq!(expected, actual);
+        let x = 0.75;
+        let expected = (0.75_f64 / (1.0 - 0.75)).ln();
+        let actual = logit(x);
+        assert_eq!(expected, actual);
+        let x = 0.25;
+        let expected = (0.25_f64 / (1.0 - 0.25)).ln();
+        let actual = logit(x);
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn logistic_transform() {
+        let data = vec![0.0, 1.0, -1.0];
+        let expected = vec![
+            0.5_f64,
+            1.0 / (1.0 + (-1.0_f64).exp()),
+            1.0 / (1.0 + 1.0_f64.exp()),
+        ];
+        let actual: Vec<_> = data.into_iter().logistic().collect();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn logit_transform() {
+        let data = vec![0.5, 0.75, 0.25];
+        let expected = vec![
+            0.0_f64,
+            (0.75_f64 / (1.0 - 0.75)).ln(),
+            (0.25_f64 / (1.0 - 0.25)).ln(),
+        ];
+        let actual: Vec<_> = data.into_iter().logit().collect();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn log_transform() {
+        let data = vec![1.0, 2.0, 3.0];
+        let expected = vec![0.0_f64, 2.0_f64.ln(), 3.0_f64.ln()];
+        let actual: Vec<_> = data.into_iter().log().collect();
+        assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn min_max_scale() {
+        let data = vec![1.0, 2.0, 3.0];
+        let min = 1.0;
+        let max = 3.0;
+        let expected = vec![0.0, 0.5, 1.0];
+        let actual: Vec<_> = data
+            .into_iter()
+            .min_max_scale(MinMaxScaleParams::new(min, max))
+            .collect();
+        assert_all_close(&expected, &actual);
+    }
+
+    #[test]
+    fn min_max_scale_custom() {
+        let data = vec![1.0, 2.0, 3.0];
+        let min = 1.0;
+        let max = 3.0;
+        let expected = vec![0.0, 5.0, 10.0];
+        let actual: Vec<_> = data
+            .into_iter()
+            .min_max_scale(MinMaxScaleParams::new(min, max).with_scaled_range(0.0, 10.0))
+            .collect();
+        assert_all_close(&expected, &actual);
+    }
+
+    #[test]
+    fn inverse_min_max_scale() {
+        let data = vec![0.0, 0.5, 1.0];
+        let min = 1.0;
+        let max = 3.0;
+        let expected = vec![1.0, 2.0, 3.0];
+        let actual: Vec<_> = data
+            .into_iter()
+            .inverse_min_max_scale(MinMaxScaleParams::new(min, max))
+            .collect();
+        assert_all_close(&expected, &actual);
+    }
+
+    #[test]
+    fn inverse_min_max_scale_custom() {
+        let data = vec![0.0, 5.0, 10.0];
+        let min = 1.0;
+        let max = 3.0;
+        let expected = vec![1.0, 2.0, 3.0];
+        let actual: Vec<_> = data
+            .into_iter()
+            .inverse_min_max_scale(MinMaxScaleParams::new(min, max).with_scaled_range(0.0, 10.0))
+            .collect();
+        assert_all_close(&expected, &actual);
+    }
+
+    #[test]
+    fn min_max_scale_params_from_data() {
+        let data = [1.0, 2.0, f64::NAN, 3.0];
+        let params = MinMaxScaleParams::from_data(data.iter().copied());
+        assert_approx_eq!(params.data_min, 1.0);
+        assert_approx_eq!(params.data_max, 3.0);
+        assert_approx_eq!(params.scaled_min, 0.0);
+        assert_approx_eq!(params.scaled_max, 1.0);
+    }
+}

--- a/crates/augurs-js/Cargo.toml
+++ b/crates/augurs-js/Cargo.toml
@@ -19,6 +19,7 @@ default = ["console_error_panic_hook"]
 [dependencies]
 augurs-core = { workspace = true }
 augurs-ets = { workspace = true, features = ["mstl"] }
+augurs-forecaster.workspace = true
 augurs-mstl = { workspace = true }
 augurs-seasons = { workspace = true }
 # The `console_error_panic_hook` crate provides better debugging of panics by

--- a/crates/augurs-js/src/lib.rs
+++ b/crates/augurs-js/src/lib.rs
@@ -1,4 +1,7 @@
 #![doc = include_str!("../README.md")]
+// Annoying, hopefully https://github.com/madonoharu/tsify/issues/42 will
+// be resolved at some point.
+#![allow(non_snake_case)]
 #![warn(
     missing_docs,
     missing_debug_implementations,

--- a/crates/augurs-js/src/mstl.rs
+++ b/crates/augurs-js/src/mstl.rs
@@ -4,7 +4,6 @@ use serde::Deserialize;
 use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
-// use augurs_core::transform::TransformExt;
 use augurs_ets::{trend::AutoETSTrendModel, AutoETS};
 use augurs_forecaster::{Forecaster, Transform};
 use augurs_mstl::{MSTLModel, TrendModel};
@@ -26,7 +25,7 @@ impl MSTL {
         self.forecaster.fit(y.to_vec()).map_err(|e| e.to_string())?;
         Ok(())
     }
-    ///
+
     /// Predict the next `horizon` values, optionally including prediction
     /// intervals at the given level.
     ///

--- a/crates/augurs-js/src/mstl.rs
+++ b/crates/augurs-js/src/mstl.rs
@@ -4,22 +4,18 @@ use serde::Deserialize;
 use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
-use augurs_ets::AutoETS;
-use augurs_mstl::{Fit, MSTLModel, TrendModel, Unfit};
+// use augurs_core::transform::TransformExt;
+use augurs_ets::{trend::AutoETSTrendModel, AutoETS};
+use augurs_forecaster::{Forecaster, Transform};
+use augurs_mstl::{MSTLModel, TrendModel};
 
 use crate::Forecast;
-
-#[derive(Debug)]
-enum MSTLEnum<T> {
-    Unfit(MSTLModel<T, Unfit>),
-    Fit(MSTLModel<T, Fit>),
-}
 
 /// A MSTL model.
 #[derive(Debug)]
 #[wasm_bindgen]
 pub struct MSTL {
-    inner: Option<MSTLEnum<Box<dyn TrendModel + Sync + Send>>>,
+    forecaster: Forecaster<MSTLModel<Box<dyn TrendModel + Send + Sync>>>,
 }
 
 #[wasm_bindgen]
@@ -27,28 +23,18 @@ impl MSTL {
     /// Fit the model to the given time series.
     #[wasm_bindgen]
     pub fn fit(&mut self, y: Float64Array) -> Result<(), JsValue> {
-        self.inner = match std::mem::take(&mut self.inner) {
-            Some(MSTLEnum::Unfit(inner)) => Some(MSTLEnum::Fit(
-                inner.fit(&y.to_vec()).map_err(|e| e.to_string())?,
-            )),
-            x => x,
-        };
+        self.forecaster.fit(y.to_vec()).map_err(|e| e.to_string())?;
         Ok(())
     }
-
+    ///
     /// Predict the next `horizon` values, optionally including prediction
     /// intervals at the given level.
     ///
     /// If provided, `level` must be a float between 0 and 1.
     #[wasm_bindgen]
     pub fn predict(&self, horizon: usize, level: Option<f64>) -> Result<Forecast, JsValue> {
-        match &self.inner {
-            Some(MSTLEnum::Fit(inner)) => Ok(inner
-                .predict(horizon, level)
-                .map(Into::into)
-                .map_err(|e| e.to_string())?),
-            _ => Err(JsValue::from_str("model is not fit")),
-        }
+        let forecasts = self.forecaster.predict(horizon, level);
+        Ok(forecasts.map(Into::into).map_err(|e| e.to_string())?)
     }
 
     /// Produce in-sample forecasts, optionally including prediction
@@ -57,13 +43,8 @@ impl MSTL {
     /// If provided, `level` must be a float between 0 and 1.
     #[wasm_bindgen]
     pub fn predict_in_sample(&self, level: Option<f64>) -> Result<Forecast, JsValue> {
-        match &self.inner {
-            Some(MSTLEnum::Fit(inner)) => Ok(inner
-                .predict_in_sample(level)
-                .map(Into::into)
-                .map_err(|e| e.to_string())?),
-            _ => Err(JsValue::from_str("model is not fit")),
-        }
+        let forecasts = self.forecaster.predict_in_sample(level);
+        Ok(forecasts.map(Into::into).map_err(|e| e.to_string())?)
     }
 }
 
@@ -72,19 +53,37 @@ impl MSTL {
 #[tsify(from_wasm_abi)]
 pub struct ETSOptions {
     /// Whether to impute missing values.
+    #[tsify(optional)]
     pub impute: Option<bool>,
+
+    /// Whether to logit-transform the data before forecasting.
+    ///
+    /// If `true`, the training data will be transformed using the logit function.
+    /// Forecasts will be back-transformed using the logistic function.
+    #[tsify(optional)]
+    pub logit_transform: Option<bool>,
+}
+
+impl ETSOptions {
+    fn into_transforms(self) -> Vec<Transform> {
+        let mut transforms = vec![];
+        if self.impute.unwrap_or_default() {
+            transforms.push(Transform::linear_interpolator());
+        }
+        if self.logit_transform.unwrap_or_default() {
+            transforms.push(Transform::logit());
+        }
+        transforms
+    }
 }
 
 #[wasm_bindgen]
 /// Create a new MSTL model with the given periods using the `AutoETS` trend model.
 pub fn ets(periods: Vec<usize>, options: Option<ETSOptions>) -> MSTL {
-    let ets: Box<dyn TrendModel + Sync + Send> = Box::new(AutoETS::non_seasonal());
-    let mut model = MSTLModel::new(periods, ets);
-    let options = options.unwrap_or_default();
-    if let Some(impute) = options.impute {
-        model = model.impute(impute);
-    }
-    MSTL {
-        inner: Some(MSTLEnum::Unfit(model)),
-    }
+    let ets: Box<dyn TrendModel + Sync + Send> =
+        Box::new(AutoETSTrendModel::from(AutoETS::non_seasonal()));
+    let model = MSTLModel::new(periods, ets);
+    let forecaster =
+        Forecaster::new(model).with_transforms(options.unwrap_or_default().into_transforms());
+    MSTL { forecaster }
 }

--- a/crates/augurs-mstl/README.md
+++ b/crates/augurs-mstl/README.md
@@ -91,10 +91,18 @@ that predicts a constant value for all time points in the horizon.
 use std::borrow::Cow;
 
 use augurs_core::{Forecast, ForecastIntervals};
-use augurs_mstl::TrendModel;
+use augurs_mstl::{FittedTrendModel, TrendModel};
 
+// The unfitted model. Sometimes this will need state!
 #[derive(Debug)]
 struct ConstantTrendModel {
+    // The constant value to predict.
+    constant: f64,
+}
+
+// The fitted model. This will invariable need state.
+#[derive(Debug)]
+struct FittedConstantTrendModel {
     // The constant value to predict.
     constant: f64,
     // The number of values in the training data.
@@ -107,18 +115,22 @@ impl TrendModel for ConstantTrendModel {
     }
 
     fn fit(
-        &mut self,
+        &self,
         y: &[f64],
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    ) -> Result<
+        Box<dyn FittedTrendModel + Sync + Send>,
+        Box<dyn std::error::Error + Send + Sync + 'static>,
+    > {
         // Your algorithm should do whatever it needs to do to fit the model.
-        // You have access to the data through the `y` slice, and a mutable
-        // reference to `self` so you can store the results of the fitting
-        // process.
-        // Here we just store the number of elements in the training data.
-        self.y_len = y.len();
-        Ok(())
+        // You need to return a boxed implementation of `FittedTrendModel`.
+        Ok(Box::new(FittedConstantTrendModel {
+            constant: self.constant,
+            y_len: y.len(),
+        }))
     }
+}
 
+impl FittedTrendModel for FittedConstantTrendModel {
     fn predict_inplace(
         &self,
         horizon: usize,

--- a/crates/augurs-mstl/benches/vic_elec.rs
+++ b/crates/augurs-mstl/benches/vic_elec.rs
@@ -1,6 +1,7 @@
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use pprof::criterion::{Output, PProfProfiler};
 
+use augurs_core::Fit;
 use augurs_mstl::{MSTLModel, NaiveTrend};
 use augurs_testing::data::VIC_ELEC;
 

--- a/crates/augurs-mstl/benches/vic_elec_iai.rs
+++ b/crates/augurs-mstl/benches/vic_elec_iai.rs
@@ -1,5 +1,6 @@
 use iai::{black_box, main};
 
+use augurs_core::Fit;
 use augurs_mstl::{MSTLModel, NaiveTrend};
 use augurs_testing::data::VIC_ELEC;
 

--- a/crates/augurs-mstl/src/lib.rs
+++ b/crates/augurs-mstl/src/lib.rs
@@ -6,15 +6,12 @@
     unreachable_pub
 )]
 
-use std::marker::PhantomData;
+use std::sync::{Arc, RwLock};
 
 use stlrs::MstlResult;
 use tracing::instrument;
 
-use augurs_core::{
-    interpolate::{InterpolateExt, LinearInterpolator},
-    Forecast, ForecastIntervals,
-};
+use augurs_core::{Forecast, ForecastIntervals, ModelError, Predict};
 
 // mod approx;
 // pub mod mstl;
@@ -23,14 +20,6 @@ mod trend;
 // mod utils;
 
 pub use crate::trend::{NaiveTrend, TrendModel};
-
-/// A marker struct indicating that a model is fit.
-#[derive(Debug, Clone, Copy)]
-pub struct Fit;
-
-/// A marker struct indicating that a model is unfit.
-#[derive(Debug, Clone, Copy)]
-pub struct Unfit;
 
 /// Errors that can occur when using this crate.
 #[derive(Debug, thiserror::Error)]
@@ -54,20 +43,17 @@ type Result<T> = std::result::Result<T, Error>;
 ///
 /// [MSTL]: https://arxiv.org/abs/2107.13462
 #[derive(Debug)]
-pub struct MSTLModel<T, F> {
+pub struct MSTLModel<T> {
     /// Periodicity of the seasonal components.
     periods: Vec<usize>,
     mstl_params: stlrs::MstlParams,
 
-    state: PhantomData<F>,
-
-    fit: Option<MstlResult>,
-    trend_model: T,
+    trend_model: Arc<RwLock<T>>,
 
     impute: bool,
 }
 
-impl MSTLModel<NaiveTrend, Unfit> {
+impl MSTLModel<NaiveTrend> {
     /// Create a new MSTL model with a naive trend model.
     ///
     /// The naive trend model predicts the last value in the training set
@@ -78,22 +64,20 @@ impl MSTLModel<NaiveTrend, Unfit> {
     }
 }
 
-impl<T: TrendModel, F> MSTLModel<T, F> {
+impl<T: TrendModel> MSTLModel<T> {
     /// Return a reference to the trend model.
-    pub fn trend_model(&self) -> &T {
+    pub fn trend_model(&self) -> &Arc<RwLock<T>> {
         &self.trend_model
     }
 }
 
-impl<T: TrendModel> MSTLModel<T, Unfit> {
+impl<T: TrendModel> MSTLModel<T> {
     /// Create a new MSTL model with the given trend model.
     pub fn new(periods: Vec<usize>, trend_model: T) -> Self {
         Self {
             periods,
-            state: PhantomData,
             mstl_params: stlrs::MstlParams::new(),
-            fit: None,
-            trend_model,
+            trend_model: Arc::new(RwLock::new(trend_model)),
             impute: false,
         }
     }
@@ -126,16 +110,8 @@ impl<T: TrendModel> MSTLModel<T, Unfit> {
     /// Any errors returned by the STL algorithm or trend model
     /// are also propagated.
     #[instrument(skip_all)]
-    pub fn fit(mut self, y: &[f64]) -> Result<MSTLModel<T, Fit>> {
-        let y: Vec<f32> = if self.impute {
-            y.iter()
-                .copied()
-                .map(|y| y as f32)
-                .interpolate(LinearInterpolator::default())
-                .collect()
-        } else {
-            y.iter().copied().map(|y| y as f32).collect::<Vec<_>>()
-        };
+    fn fit_impl(&self, y: &[f64]) -> Result<FittedMSTLModel<T>> {
+        let y: Vec<f32> = y.iter().copied().map(|y| y as f32).collect::<Vec<_>>();
         let fit = self.mstl_params.fit(&y, &self.periods)?;
         // Determine the differencing term for the trend component.
         let trend = fit.trend();
@@ -146,78 +122,69 @@ impl<T: TrendModel> MSTLModel<T, Unfit> {
             .map(|(t, r)| (t + r) as f64)
             .collect::<Vec<_>>();
         self.trend_model
+            .write()
+            .unwrap()
             .fit(&deseasonalised)
             .map_err(Error::TrendModel)?;
         tracing::trace!(
             trend_model = ?self.trend_model,
             "found best trend model",
         );
-        Ok(MSTLModel {
-            periods: self.periods,
-            mstl_params: self.mstl_params,
-            state: PhantomData,
-            fit: Some(fit),
-            trend_model: self.trend_model,
-            impute: self.impute,
+        Ok(FittedMSTLModel {
+            periods: self.periods.clone(),
+            fit,
+            trend_model: Arc::clone(&self.trend_model),
         })
     }
 }
 
-impl<T: TrendModel> MSTLModel<T, Fit> {
-    /// Return the n-ahead predictions for the given horizon.
-    ///
-    /// The predictions are point forecasts and optionally include
-    /// prediction intervals at the specified `level`.
-    ///
-    /// `level` should be a float between 0 and 1 representing the
-    /// confidence level of the prediction intervals. If `None` then
-    /// no prediction intervals are returned.
-    ///
-    /// # Errors
-    ///
-    /// Any errors returned by the trend model are propagated.
-    pub fn predict(&self, horizon: usize, level: impl Into<Option<f64>>) -> Result<Forecast> {
-        self.predict_impl(horizon, level.into())
-    }
+/// A model that uses the [MSTL] to decompose a time series into trend,
+/// seasonal and remainder components, and then uses a trend model to
+/// forecast the trend component.
+///
+/// [MSTL]: https://arxiv.org/abs/2107.13462
+#[derive(Debug)]
+pub struct FittedMSTLModel<T> {
+    /// Periodicity of the seasonal components.
+    periods: Vec<usize>,
+    fit: MstlResult,
+    trend_model: Arc<RwLock<T>>,
+}
 
-    fn predict_impl(&self, horizon: usize, level: Option<f64>) -> Result<Forecast> {
+impl<T> FittedMSTLModel<T> {
+    /// Return the MSTL fit of the training data.
+    pub fn fit(&self) -> &MstlResult {
+        &self.fit
+    }
+}
+
+impl<T: TrendModel> FittedMSTLModel<T> {
+    fn predict_impl(
+        &self,
+        horizon: usize,
+        level: Option<f64>,
+        forecast: &mut Forecast,
+    ) -> Result<()> {
         if horizon == 0 {
-            return Ok(Forecast {
-                point: vec![],
-                intervals: level.map(ForecastIntervals::empty),
-            });
+            return Ok(());
         }
-        let mut out_of_sample = self
-            .trend_model
-            .predict(horizon, level)
+        self.trend_model
+            .read()
+            .unwrap()
+            .predict_inplace(horizon, level, forecast)
             .map_err(Error::TrendModel)?;
-        self.add_seasonal_out_of_sample(&mut out_of_sample);
-        Ok(out_of_sample)
+        self.add_seasonal_out_of_sample(forecast);
+        Ok(())
     }
 
-    /// Return the in-sample predictions.
-    ///
-    /// The predictions are point forecasts and optionally include
-    /// prediction intervals at the specified `level`.
-    ///
-    /// `level` should be a float between 0 and 1 representing the
-    /// confidence level of the prediction intervals. If `None` then
-    /// no prediction intervals are returned.
-    ///
-    /// # Errors
-    ///
-    /// Any errors returned by the trend model are propagated.
-    pub fn predict_in_sample(&self, level: impl Into<Option<f64>>) -> Result<Forecast> {
-        self.predict_in_sample_impl(level.into())
-    }
-
-    fn predict_in_sample_impl(&self, level: Option<f64>) -> Result<Forecast> {
-        let mut in_sample = self
-            .trend_model
-            .predict_in_sample(level)
+    fn predict_in_sample_impl(&self, level: Option<f64>, forecast: &mut Forecast) -> Result<()> {
+        self.trend_model
+            .read()
+            .unwrap()
+            .predict_in_sample_inplace(level, forecast)
             .map_err(Error::TrendModel)?;
-        self.add_seasonal_in_sample(&mut in_sample);
-        Ok(in_sample)
+        self.add_seasonal_in_sample(forecast);
+        Ok(())
     }
 
     fn add_seasonal_in_sample(&self, trend: &mut Forecast) {
@@ -278,10 +245,36 @@ impl<T: TrendModel> MSTLModel<T, Fit> {
                 }
             });
     }
+}
 
-    /// Return the MSTL fit of the training data.
-    pub fn fit(&self) -> &MstlResult {
-        self.fit.as_ref().unwrap()
+impl ModelError for Error {}
+
+impl<T: TrendModel> augurs_core::Fit for MSTLModel<T> {
+    type Fitted = FittedMSTLModel<T>;
+    type Error = Error;
+    fn fit(&self, y: &[f64]) -> Result<Self::Fitted> {
+        self.fit_impl(y)
+    }
+}
+
+impl<T: TrendModel> Predict for FittedMSTLModel<T> {
+    type Error = Error;
+
+    fn predict_inplace(
+        &self,
+        horizon: usize,
+        level: Option<f64>,
+        forecast: &mut Forecast,
+    ) -> Result<()> {
+        self.predict_impl(horizon, level, forecast)
+    }
+
+    fn predict_in_sample_inplace(&self, level: Option<f64>, forecast: &mut Forecast) -> Result<()> {
+        self.predict_in_sample_impl(level, forecast)
+    }
+
+    fn training_data_size(&self) -> usize {
+        self.fit().trend().len()
     }
 }
 
@@ -289,6 +282,7 @@ impl<T: TrendModel> MSTLModel<T, Fit> {
 mod tests {
     use assert_approx_eq::assert_approx_eq;
 
+    use augurs_core::prelude::*;
     use augurs_testing::data::VIC_ELEC;
 
     use crate::{trend::NaiveTrend, ForecastIntervals, MSTLModel};

--- a/crates/augurs-mstl/src/trend.rs
+++ b/crates/augurs-mstl/src/trend.rs
@@ -33,11 +33,12 @@ pub trait TrendModel: Debug {
     /// The `level` parameter specifies the confidence level for the prediction intervals.
     /// Where possible, implementations should provide prediction intervals
     /// alongside the point forecasts if `level` is not `None`.
-    fn predict(
+    fn predict_inplace(
         &self,
         horizon: usize,
         level: Option<f64>,
-    ) -> Result<Forecast, Box<dyn std::error::Error + Send + Sync + 'static>>;
+        forecast: &mut Forecast,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>;
 
     /// Produce in-sample predictions.
     ///
@@ -46,10 +47,62 @@ pub trait TrendModel: Debug {
     /// The `level` parameter specifies the confidence level for the prediction intervals.
     /// Where possible, implementations should provide prediction intervals
     /// alongside the point forecasts if `level` is not `None`.
+    fn predict_in_sample_inplace(
+        &self,
+        level: Option<f64>,
+        forecast: &mut Forecast,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>;
+
+    /// Return the n-ahead predictions for the given horizon.
+    ///
+    /// The predictions are point forecasts and optionally include
+    /// prediction intervals at the specified `level`.
+    ///
+    /// `level` should be a float between 0 and 1 representing the
+    /// confidence level of the prediction intervals. If `None` then
+    /// no prediction intervals are returned.
+    ///
+    /// # Errors
+    ///
+    /// Any errors returned by the trend model are propagated.
+    fn predict(
+        &self,
+        horizon: usize,
+        level: Option<f64>,
+    ) -> Result<Forecast, Box<dyn std::error::Error + Send + Sync + 'static>> {
+        let mut forecast = level
+            .map(|l| Forecast::with_capacity_and_level(horizon, l))
+            .unwrap_or_else(|| Forecast::with_capacity(horizon));
+        self.predict_inplace(horizon, level, &mut forecast)?;
+        Ok(forecast)
+    }
+
+    /// Return the in-sample predictions.
+    ///
+    /// The predictions are point forecasts and optionally include
+    /// prediction intervals at the specified `level`.
+    ///
+    /// `level` should be a float between 0 and 1 representing the
+    /// confidence level of the prediction intervals. If `None` then
+    /// no prediction intervals are returned.
+    ///
+    /// # Errors
+    ///
+    /// Any errors returned by the trend model are propagated.
     fn predict_in_sample(
         &self,
         level: Option<f64>,
-    ) -> Result<Forecast, Box<dyn std::error::Error + Send + Sync + 'static>>;
+    ) -> Result<Forecast, Box<dyn std::error::Error + Send + Sync + 'static>> {
+        let mut forecast = level
+            .zip(self.training_data_size())
+            .map(|(l, c)| Forecast::with_capacity_and_level(c, l))
+            .unwrap_or_else(|| Forecast::with_capacity(0));
+        self.predict_in_sample_inplace(level, &mut forecast)?;
+        Ok(forecast)
+    }
+
+    /// Return the number of training data points used to fit the model.
+    fn training_data_size(&self) -> Option<usize>;
 }
 
 impl<T: TrendModel + ?Sized> TrendModel for Box<T> {
@@ -61,25 +114,31 @@ impl<T: TrendModel + ?Sized> TrendModel for Box<T> {
         (**self).fit(y)
     }
 
-    fn predict(
+    fn predict_inplace(
         &self,
         horizon: usize,
         level: Option<f64>,
-    ) -> Result<Forecast, Box<dyn std::error::Error + Send + Sync + 'static>> {
-        (**self).predict(horizon, level)
+        forecast: &mut Forecast,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+        (**self).predict_inplace(horizon, level, forecast)
     }
 
-    fn predict_in_sample(
+    fn predict_in_sample_inplace(
         &self,
         level: Option<f64>,
-    ) -> Result<Forecast, Box<dyn std::error::Error + Send + Sync + 'static>> {
-        (**self).predict_in_sample(level)
+        forecast: &mut Forecast,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+        (**self).predict_in_sample_inplace(level, forecast)
+    }
+
+    fn training_data_size(&self) -> Option<usize> {
+        (**self).training_data_size()
     }
 }
 
 /// A naive trend model that predicts the last value in the training set
 /// for all future time points.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct NaiveTrend {
     fitted: Option<Vec<f64>>,
     last_value: Option<f64>,
@@ -117,17 +176,14 @@ impl NaiveTrend {
         preds: impl Iterator<Item = f64>,
         level: f64,
         sigma: impl Iterator<Item = f64>,
-    ) -> ForecastIntervals {
+        intervals: &mut ForecastIntervals,
+    ) {
+        intervals.level = level;
         let z = distrs::Normal::ppf(0.5 + level / 2.0, 0.0, 1.0);
-        let (lower, upper) = preds
+        (intervals.lower, intervals.upper) = preds
             .zip(sigma)
             .map(|(p, s)| (p - z * s, p + z * s))
             .unzip();
-        ForecastIntervals {
-            level,
-            lower,
-            upper,
-        }
     }
 }
 
@@ -159,41 +215,55 @@ impl TrendModel for NaiveTrend {
         Ok(())
     }
 
-    fn predict(
+    fn predict_inplace(
         &self,
         horizon: usize,
         level: Option<f64>,
-    ) -> Result<Forecast, Box<dyn std::error::Error + Send + Sync + 'static>> {
+        forecast: &mut Forecast,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         match self.last_value.zip(self.sigma_squared) {
-            Some((l, sigma)) => Ok(Forecast {
-                point: vec![l; horizon],
-                intervals: level.map(|level| {
+            Some((l, sigma)) => {
+                forecast.point = vec![l; horizon];
+                if let Some(level) = level {
                     let sigmas = (1..horizon + 1).map(|step| ((step as f64) * sigma).sqrt());
-                    self.prediction_intervals(std::iter::repeat(l), level, sigmas)
-                }),
-            }),
+                    let intervals = forecast
+                        .intervals
+                        .get_or_insert_with(|| ForecastIntervals::with_capacity(level, horizon));
+                    self.prediction_intervals(std::iter::repeat(l), level, sigmas, intervals);
+                }
+                Ok(())
+            }
             None => Err("model not fit")?,
         }
     }
 
-    fn predict_in_sample(
+    fn predict_in_sample_inplace(
         &self,
         level: Option<f64>,
-    ) -> Result<Forecast, Box<dyn std::error::Error + Send + Sync + 'static>> {
+        forecast: &mut Forecast,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
         Ok(self
             .fitted
             .as_ref()
             .zip(self.sigma_squared)
-            .map(|(fitted, sigma)| Forecast {
-                point: fitted.clone(),
-                intervals: level.map(|level| {
+            .map(|(fitted, sigma)| {
+                forecast.point = fitted.clone();
+                if let Some(level) = level {
+                    let intervals = forecast.intervals.get_or_insert_with(|| {
+                        ForecastIntervals::with_capacity(level, fitted.len())
+                    });
                     self.prediction_intervals(
                         fitted.iter().copied(),
                         level,
                         std::iter::repeat(sigma.sqrt()),
-                    )
-                }),
+                        intervals,
+                    );
+                }
             })
             .ok_or("model not fit")?)
+    }
+
+    fn training_data_size(&self) -> Option<usize> {
+        self.fitted.as_ref().map(Vec::len)
     }
 }

--- a/crates/augurs-seasons/LICENSE-APACHE
+++ b/crates/augurs-seasons/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../../LICENSE-APACHE

--- a/crates/augurs-seasons/LICENSE-MIT
+++ b/crates/augurs-seasons/LICENSE-MIT
@@ -1,0 +1,1 @@
+../../LICENSE-MIT

--- a/crates/augurs-testing/Cargo.toml
+++ b/crates/augurs-testing/Cargo.toml
@@ -10,4 +10,5 @@ keywords.workspace = true
 description = "Test framework and data for the augurs library."
 
 [dependencies]
+assert_approx_eq = "1.1.0"
 once_cell = "1.18.0"

--- a/crates/augurs-testing/src/lib.rs
+++ b/crates/augurs-testing/src/lib.rs
@@ -11,3 +11,17 @@
 )]
 
 pub mod data;
+
+pub use assert_approx_eq::assert_approx_eq;
+
+/// Assert that two slices are approximately equal.
+#[track_caller]
+pub fn assert_all_close(actual: &[f64], expected: &[f64]) {
+    for (actual, expected) in actual.iter().zip(expected) {
+        if actual.is_nan() {
+            assert!(expected.is_nan());
+        } else {
+            assert_approx_eq!(actual, expected, 1e-1);
+        }
+    }
+}

--- a/crates/pyaugurs/Cargo.toml
+++ b/crates/pyaugurs/Cargo.toml
@@ -17,6 +17,7 @@ crate-type = ["cdylib"]
 [dependencies]
 augurs-core.workspace = true
 augurs-ets = { workspace = true, features = ["mstl"] }
+augurs-forecaster.workspace = true
 augurs-mstl.workspace = true
 augurs-seasons.workspace = true
 numpy = "0.21.0"


### PR DESCRIPTION
This rather large commit adds a new `Forecaster` struct under the new
`augurs-forecaster` crate, which provides a higher level API
combining transforming input data, fitting and predicting. This means
that models (e.g. the MSTL model) don't need to concern themselves with
the potentially unlimited number of transformations that could need to
happen on the input data, and instead just fit their models as normal.

In doing so I needed to rework the APIs of the other models somewhat, to
make them fit into a new `Fit` / `Predict` API, which makes them much
easier to use (vs the old `Fit` / `Unfit` marker trait). The new APIs
are similar to those used by `linfa`.

The new `Predict` API also allows users to pass in a pre-allocated
`Forecast` which allows for an optimization if multiple predictions are
being made.