### PR TITLE
fix(ci): restrict Python versions in Python CI

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,6 +24,7 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -33,7 +34,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter --manifest-path crates/pyaugurs/Cargo.toml
+          args: --release --out dist --interpreter ${{ matrix.python-version }} --manifest-path crates/pyaugurs/Cargo.toml
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
@@ -47,6 +48,7 @@ jobs:
     strategy:
       matrix:
         target: [x64, x86]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -57,7 +59,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter --manifest-path crates/pyaugurs/Cargo.toml
+          args: --release --out dist --interpreter ${{ matrix.python-version }} --manifest-path crates/pyaugurs/Cargo.toml
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v3
@@ -70,6 +72,7 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, aarch64]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -79,7 +82,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --find-interpreter --manifest-path crates/pyaugurs/Cargo.toml
+          args: --release --out dist --interpreter ${{ matrix.python-version }} --manifest-path crates/pyaugurs/Cargo.toml
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -24,7 +24,6 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -34,7 +33,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter ${{ matrix.python-version }} --manifest-path crates/pyaugurs/Cargo.toml
+          args: --release --out dist -i 3.7 -i 3.8 -i 3.9 -i 3.10 -i 3.11 -i 3.12 --manifest-path crates/pyaugurs/Cargo.toml
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
@@ -48,7 +47,6 @@ jobs:
     strategy:
       matrix:
         target: [x64, x86]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -59,7 +57,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter ${{ matrix.python-version }} --manifest-path crates/pyaugurs/Cargo.toml
+          args: --release --out dist -i 3.7 -i 3.8 -i 3.9 -i 3.10 -i 3.11 -i 3.12 --manifest-path crates/pyaugurs/Cargo.toml
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v3
@@ -72,7 +70,6 @@ jobs:
     strategy:
       matrix:
         target: [x86_64, aarch64]
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -82,7 +79,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: --release --out dist --interpreter ${{ matrix.python-version }} --manifest-path crates/pyaugurs/Cargo.toml
+          args: --release --out dist -i 3.7 -i 3.8 -i 3.9 -i 3.10 -i 3.11 -i 3.12 --manifest-path crates/pyaugurs/Cargo.toml
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Builds are currently failing because the maturin action is attempting to
build the wheel for every Python interpreter in the linux job. This
includes an alpha version of 3.13, but since 0.20.3 pyo3 will refuse to
build for that version of Python because forward-compatibility with
future 3.13 versions isn't guaranteed. We've also ended up with some
3.13 versions of augurs on PyPI :(

This commit restricts the versions to 3.7 - 3.12, the currently
supported versions of Python.

In future it's possible that maturin will allow us to only include
non-alpha/beta versions of Python with the '--find-interpreter' flag,
but until then we'll need to update them manually.

Relevant issue: https://github.com/PyO3/maturin/issues/1960