### PR TITLE
chore: remove 'version' from augurs-testing dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ augurs-core = { version = "0.1.2", path = "crates/augurs-core" }
 augurs-ets = { version = "0.1.2", path = "crates/augurs-ets" }
 augurs-mstl = { version = "0.1.2", path = "crates/augurs-mstl" }
 augurs-seasons = { version = "0.1.2", path = "crates/augurs-seasons" }
-augurs-testing = { version = "0.1.2", path = "crates/augurs-testing" }
+augurs-testing = { path = "crates/augurs-testing" }
 
 distrs = "0.2.1"
 itertools = "0.12.0"


### PR DESCRIPTION
Otherwise it's published to crates.io which isn't needed since it's
just a dev dependency for testing.

Related: https://github.com/MarcoIeni/release-plz/issues/1316.