### PR TITLE
feat: use `tsify-next` instead of `tsify`

### DIFF
--- a/crates/augurs-js/Cargo.toml
+++ b/crates/augurs-js/Cargo.toml
@@ -34,5 +34,5 @@ js-sys = "0.3.64"
 serde.workspace = true
 serde-wasm-bindgen = "0.6.0"
 tracing-wasm = { version = "0.2.1", optional = true }
-tsify = { version = "0.4.5", default-features = false, features = ["js"] }
+tsify-next = { version = "0.5.3", default-features = false, features = ["js"] }
 wasm-bindgen = "0.2.87"

--- a/crates/augurs-js/src/changepoints.rs
+++ b/crates/augurs-js/src/changepoints.rs
@@ -2,7 +2,7 @@ use std::num::NonZeroUsize;
 
 use js_sys::Float64Array;
 use serde::{Deserialize, Serialize};
-use tsify::Tsify;
+use tsify_next::Tsify;
 use wasm_bindgen::prelude::*;
 
 use augurs_changepoint::{

--- a/crates/augurs-js/src/lib.rs
+++ b/crates/augurs-js/src/lib.rs
@@ -10,7 +10,7 @@
 )]
 
 use serde::Serialize;
-use tsify::Tsify;
+use tsify_next::Tsify;
 use wasm_bindgen::prelude::*;
 
 mod changepoints;

--- a/crates/augurs-js/src/mstl.rs
+++ b/crates/augurs-js/src/mstl.rs
@@ -1,7 +1,7 @@
 //! JavaScript bindings for the MSTL model.
 use js_sys::Float64Array;
 use serde::Deserialize;
-use tsify::Tsify;
+use tsify_next::Tsify;
 use wasm_bindgen::prelude::*;
 
 use augurs_ets::{trend::AutoETSTrendModel, AutoETS};

--- a/crates/augurs-js/src/outlier.rs
+++ b/crates/augurs-js/src/outlier.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use augurs_outlier::OutlierDetector as _;
 use js_sys::Float64Array;
 use serde::{Deserialize, Serialize};
-use tsify::Tsify;
+use tsify_next::Tsify;
 
 use wasm_bindgen::prelude::*;
 

--- a/crates/augurs-js/src/seasons.rs
+++ b/crates/augurs-js/src/seasons.rs
@@ -1,7 +1,7 @@
 //! Javascript bindings for augurs seasonality detection.
 
 use serde::Deserialize;
-use tsify::Tsify;
+use tsify_next::Tsify;
 use wasm_bindgen::prelude::*;
 
 use augurs_seasons::{Detector, PeriodogramDetector};


### PR DESCRIPTION
A bunch of new features have been merged into this fork, so it's worth switching to.