### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 documentation = "https://docs.rs/crate/augurs"
 repository = "https://github.com/grafana/augurs"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 keywords = [
   "analysis",

--- a/crates/augurs-changepoint/CHANGELOG.md
+++ b/crates/augurs-changepoint/CHANGELOG.md
@@ -6,3 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.1.2...augurs-changepoint-v0.2.0) - 2024-06-05
+
+### Other
+- Add empty CHANGELOGs
+

--- a/crates/augurs-core/CHANGELOG.md
+++ b/crates/augurs-core/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/grafana/augurs/compare/augurs-core-v0.1.2...augurs-core-v0.2.0) - 2024-06-05
+
+### Added
+- [**breaking**] add transformations and high-level forecasting API ([#65](https://github.com/grafana/augurs/pull/65))
+
 ## [0.1.2](https://github.com/grafana/augurs/compare/augurs-core-v0.1.1...augurs-core-v0.1.2) - 2024-02-20
 
 ### Added

--- a/crates/augurs-ets/CHANGELOG.md
+++ b/crates/augurs-ets/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/grafana/augurs/compare/augurs-ets-v0.1.2...augurs-ets-v0.2.0) - 2024-06-05
+
+### Added
+- [**breaking**] add transformations and high-level forecasting API ([#65](https://github.com/grafana/augurs/pull/65))
+
+### Other
+- Silence nightly clippy warning
+- use clone_from instead of assigning result of clone ([#73](https://github.com/grafana/augurs/pull/73))
+
 ## [0.1.1](https://github.com/grafana/augurs/compare/augurs-ets-v0.1.0...augurs-ets-v0.1.1) - 2024-02-15
 
 ### Other

--- a/crates/augurs-forecaster/CHANGELOG.md
+++ b/crates/augurs-forecaster/CHANGELOG.md
@@ -6,3 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.1.2...augurs-forecaster-v0.2.0) - 2024-06-05
+
+### Added
+- [**breaking**] add transformations and high-level forecasting API ([#65](https://github.com/grafana/augurs/pull/65))
+
+### Other
+- Add empty CHANGELOGs
+

--- a/crates/augurs-mstl/CHANGELOG.md
+++ b/crates/augurs-mstl/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/grafana/augurs/compare/augurs-mstl-v0.1.2...augurs-mstl-v0.2.0) - 2024-06-05
+
+### Added
+- [**breaking**] add transformations and high-level forecasting API ([#65](https://github.com/grafana/augurs/pull/65))
+
+### Other
+- use clone_from instead of assigning result of clone ([#73](https://github.com/grafana/augurs/pull/73))
+
 ## [0.1.2](https://github.com/grafana/augurs/compare/augurs-mstl-v0.1.1...augurs-mstl-v0.1.2) - 2024-02-20
 
 ### Added

--- a/crates/augurs-outlier/CHANGELOG.md
+++ b/crates/augurs-outlier/CHANGELOG.md
@@ -6,3 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.1.2...augurs-outlier-v0.2.0) - 2024-06-05
+
+### Added
+- add outlier crate with DBSCAN implementation ([#79](https://github.com/grafana/augurs/pull/79))
+
+### Other
+- Add empty CHANGELOGs
+

--- a/crates/augurs-seasons/CHANGELOG.md
+++ b/crates/augurs-seasons/CHANGELOG.md
@@ -5,3 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0](https://github.com/grafana/augurs/compare/augurs-seasons-v0.1.2...augurs-seasons-v0.2.0) - 2024-06-05
+
+### Added
+- [**breaking**] add transformations and high-level forecasting API ([#65](https://github.com/grafana/augurs/pull/65))
+
+### Other
+- Update itertools requirement from 0.12.0 to 0.13.0 ([#75](https://github.com/grafana/augurs/pull/75))

--- a/crates/augurs-testing/CHANGELOG.md
+++ b/crates/augurs-testing/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/grafana/augurs/compare/augurs-testing-v0.1.2...augurs-testing-v0.2.0) - 2024-06-05
+
+### Added
+- [**breaking**] add transformations and high-level forecasting API ([#65](https://github.com/grafana/augurs/pull/65))
+
 ## [0.1.1](https://github.com/grafana/augurs/compare/augurs-testing-v0.1.0...augurs-testing-v0.1.1) - 2024-02-15
 
 ### Other


### PR DESCRIPTION
## 🤖 New release
* `augurs-changepoint`: 0.1.2 -> 0.2.0
* `augurs-core`: 0.1.2 -> 0.2.0
* `augurs-testing`: 0.1.2 -> 0.2.0
* `augurs-ets`: 0.1.2 -> 0.2.0
* `augurs-mstl`: 0.1.2 -> 0.2.0
* `augurs-forecaster`: 0.1.2 -> 0.2.0
* `augurs-outlier`: 0.1.2 -> 0.2.0
* `augurs-seasons`: 0.1.2 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `augurs-changepoint`
<blockquote>

## [0.2.0](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.1.2...augurs-changepoint-v0.2.0) - 2024-06-05

### Other
- Add empty CHANGELOGs
</blockquote>

## `augurs-core`
<blockquote>

## [0.2.0](https://github.com/grafana/augurs/compare/augurs-core-v0.1.2...augurs-core-v0.2.0) - 2024-06-05

### Added
- [**breaking**] add transformations and high-level forecasting API ([#65](https://github.com/grafana/augurs/pull/65))
</blockquote>

## `augurs-testing`
<blockquote>

## [0.2.0](https://github.com/grafana/augurs/compare/augurs-testing-v0.1.2...augurs-testing-v0.2.0) - 2024-06-05

### Added
- [**breaking**] add transformations and high-level forecasting API ([#65](https://github.com/grafana/augurs/pull/65))
</blockquote>

## `augurs-ets`
<blockquote>

## [0.2.0](https://github.com/grafana/augurs/compare/augurs-ets-v0.1.2...augurs-ets-v0.2.0) - 2024-06-05

### Added
- [**breaking**] add transformations and high-level forecasting API ([#65](https://github.com/grafana/augurs/pull/65))

### Other
- Silence nightly clippy warning
- use clone_from instead of assigning result of clone ([#73](https://github.com/grafana/augurs/pull/73))
</blockquote>

## `augurs-mstl`
<blockquote>

## [0.2.0](https://github.com/grafana/augurs/compare/augurs-mstl-v0.1.2...augurs-mstl-v0.2.0) - 2024-06-05

### Added
- [**breaking**] add transformations and high-level forecasting API ([#65](https://github.com/grafana/augurs/pull/65))

### Other
- use clone_from instead of assigning result of clone ([#73](https://github.com/grafana/augurs/pull/73))
</blockquote>

## `augurs-forecaster`
<blockquote>

## [0.2.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.1.2...augurs-forecaster-v0.2.0) - 2024-06-05

### Added
- [**breaking**] add transformations and high-level forecasting API ([#65](https://github.com/grafana/augurs/pull/65))

### Other
- Add empty CHANGELOGs
</blockquote>

## `augurs-outlier`
<blockquote>

## [0.2.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.1.2...augurs-outlier-v0.2.0) - 2024-06-05

### Added
- add outlier crate with DBSCAN implementation ([#79](https://github.com/grafana/augurs/pull/79))

### Other
- Add empty CHANGELOGs
</blockquote>

## `augurs-seasons`
<blockquote>

## [0.2.0](https://github.com/grafana/augurs/compare/augurs-seasons-v0.1.2...augurs-seasons-v0.2.0) - 2024-06-05

### Added
- [**breaking**] add transformations and high-level forecasting API ([#65](https://github.com/grafana/augurs/pull/65))

### Other
- Update itertools requirement from 0.12.0 to 0.13.0 ([#75](https://github.com/grafana/augurs/pull/75))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).