### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 documentation = "https://docs.rs/crate/augurs"
 repository = "https://github.com/grafana/augurs"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 keywords = [
   "analysis",
@@ -22,13 +22,13 @@ keywords = [
 
 [workspace.dependencies]
 
-augurs-changepoint = { version = "0.2.0", path = "crates/augurs-changepoint" }
-augurs-core = { version = "0.2.0", path = "crates/augurs-core" }
-augurs-ets = { version = "0.2.0", path = "crates/augurs-ets" }
+augurs-changepoint = { version = "0.2.1", path = "crates/augurs-changepoint" }
+augurs-core = { version = "0.2.1", path = "crates/augurs-core" }
+augurs-ets = { version = "0.2.1", path = "crates/augurs-ets" }
 augurs-forecaster = { path = "crates/augurs-forecaster" }
-augurs-mstl = { version = "0.2.0", path = "crates/augurs-mstl" }
-augurs-outlier = { version = "0.2.0", path = "crates/augurs-outlier" }
-augurs-seasons = { version = "0.2.0", path = "crates/augurs-seasons" }
+augurs-mstl = { version = "0.2.1", path = "crates/augurs-mstl" }
+augurs-outlier = { version = "0.2.1", path = "crates/augurs-outlier" }
+augurs-seasons = { version = "0.2.1", path = "crates/augurs-seasons" }
 augurs-testing = { path = "crates/augurs-testing" }
 
 distrs = "0.2.1"

--- a/crates/augurs-changepoint/CHANGELOG.md
+++ b/crates/augurs-changepoint/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.2.0...augurs-changepoint-v0.2.1) - 2024-06-24
+
+### Other
+- Remove unsupported .github/workflows/bencher subdirectory and old benchmark workflow ([#90](https://github.com/grafana/augurs/pull/90))
+
 ## [0.2.0](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.1.2...augurs-changepoint-v0.2.0) - 2024-06-05
 
 ### Other

--- a/crates/augurs-core/CHANGELOG.md
+++ b/crates/augurs-core/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/grafana/augurs/compare/augurs-core-v0.2.0...augurs-core-v0.2.1) - 2024-06-24
+
+### Other
+- Remove unsupported .github/workflows/bencher subdirectory and old benchmark workflow ([#90](https://github.com/grafana/augurs/pull/90))
+
 ## [0.2.0](https://github.com/grafana/augurs/compare/augurs-core-v0.1.2...augurs-core-v0.2.0) - 2024-06-05
 
 ### Added

--- a/crates/augurs-ets/CHANGELOG.md
+++ b/crates/augurs-ets/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/grafana/augurs/compare/augurs-ets-v0.2.0...augurs-ets-v0.2.1) - 2024-06-24
+
+### Other
+- Remove unsupported .github/workflows/bencher subdirectory and old benchmark workflow ([#90](https://github.com/grafana/augurs/pull/90))
+
 ## [0.2.0](https://github.com/grafana/augurs/compare/augurs-ets-v0.1.2...augurs-ets-v0.2.0) - 2024-06-05
 
 ### Added

--- a/crates/augurs-forecaster/CHANGELOG.md
+++ b/crates/augurs-forecaster/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.2.0...augurs-forecaster-v0.2.1) - 2024-06-24
+
+### Other
+- Remove unsupported .github/workflows/bencher subdirectory and old benchmark workflow ([#90](https://github.com/grafana/augurs/pull/90))
+
 ## [0.2.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.1.2...augurs-forecaster-v0.2.0) - 2024-06-05
 
 ### Added

--- a/crates/augurs-mstl/CHANGELOG.md
+++ b/crates/augurs-mstl/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/grafana/augurs/compare/augurs-mstl-v0.2.0...augurs-mstl-v0.2.1) - 2024-06-24
+
+### Other
+- Remove unsupported .github/workflows/bencher subdirectory and old benchmark workflow ([#90](https://github.com/grafana/augurs/pull/90))
+
 ## [0.2.0](https://github.com/grafana/augurs/compare/augurs-mstl-v0.1.2...augurs-mstl-v0.2.0) - 2024-06-05
 
 ### Added

--- a/crates/augurs-outlier/CHANGELOG.md
+++ b/crates/augurs-outlier/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/grafana/augurs/compare/augurs-outlier-v0.2.0...augurs-outlier-v0.2.1) - 2024-06-24
+
+### Other
+- Remove unsupported .github/workflows/bencher subdirectory and old benchmark workflow ([#90](https://github.com/grafana/augurs/pull/90))
+
 ## [0.2.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.1.2...augurs-outlier-v0.2.0) - 2024-06-05
 
 ### Added

--- a/crates/augurs-seasons/CHANGELOG.md
+++ b/crates/augurs-seasons/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/grafana/augurs/compare/augurs-seasons-v0.2.0...augurs-seasons-v0.2.1) - 2024-06-24
+
+### Other
+- Remove unsupported .github/workflows/bencher subdirectory and old benchmark workflow ([#90](https://github.com/grafana/augurs/pull/90))
+
 ## [0.2.0](https://github.com/grafana/augurs/compare/augurs-seasons-v0.1.2...augurs-seasons-v0.2.0) - 2024-06-05
 
 ### Added

--- a/crates/augurs-testing/CHANGELOG.md
+++ b/crates/augurs-testing/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/grafana/augurs/compare/augurs-testing-v0.2.0...augurs-testing-v0.2.1) - 2024-06-24
+
+### Other
+- Remove unsupported .github/workflows/bencher subdirectory and old benchmark workflow ([#90](https://github.com/grafana/augurs/pull/90))
+
 ## [0.2.0](https://github.com/grafana/augurs/compare/augurs-testing-v0.1.2...augurs-testing-v0.2.0) - 2024-06-05
 
 ### Added


### PR DESCRIPTION
## 🤖 New release
* `augurs-changepoint`: 0.2.0 -> 0.2.1
* `augurs-core`: 0.2.0 -> 0.2.1
* `augurs-testing`: 0.2.0 -> 0.2.1
* `augurs-ets`: 0.2.0 -> 0.2.1
* `augurs-mstl`: 0.2.0 -> 0.2.1
* `augurs-forecaster`: 0.2.0 -> 0.2.1
* `augurs-outlier`: 0.2.0 -> 0.2.1
* `augurs-seasons`: 0.2.0 -> 0.2.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `augurs-changepoint`
<blockquote>

## [0.2.1](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.2.0...augurs-changepoint-v0.2.1) - 2024-06-24

### Other
- Remove unsupported .github/workflows/bencher subdirectory and old benchmark workflow ([#90](https://github.com/grafana/augurs/pull/90))
</blockquote>

## `augurs-core`
<blockquote>

## [0.2.1](https://github.com/grafana/augurs/compare/augurs-core-v0.2.0...augurs-core-v0.2.1) - 2024-06-24

### Other
- Remove unsupported .github/workflows/bencher subdirectory and old benchmark workflow ([#90](https://github.com/grafana/augurs/pull/90))
</blockquote>

## `augurs-testing`
<blockquote>

## [0.2.1](https://github.com/grafana/augurs/compare/augurs-testing-v0.2.0...augurs-testing-v0.2.1) - 2024-06-24

### Other
- Remove unsupported .github/workflows/bencher subdirectory and old benchmark workflow ([#90](https://github.com/grafana/augurs/pull/90))
</blockquote>

## `augurs-ets`
<blockquote>

## [0.2.1](https://github.com/grafana/augurs/compare/augurs-ets-v0.2.0...augurs-ets-v0.2.1) - 2024-06-24

### Other
- Remove unsupported .github/workflows/bencher subdirectory and old benchmark workflow ([#90](https://github.com/grafana/augurs/pull/90))
</blockquote>

## `augurs-mstl`
<blockquote>

## [0.2.1](https://github.com/grafana/augurs/compare/augurs-mstl-v0.2.0...augurs-mstl-v0.2.1) - 2024-06-24

### Other
- Remove unsupported .github/workflows/bencher subdirectory and old benchmark workflow ([#90](https://github.com/grafana/augurs/pull/90))
</blockquote>

## `augurs-forecaster`
<blockquote>

## [0.2.1](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.2.0...augurs-forecaster-v0.2.1) - 2024-06-24

### Other
- Remove unsupported .github/workflows/bencher subdirectory and old benchmark workflow ([#90](https://github.com/grafana/augurs/pull/90))
</blockquote>

## `augurs-outlier`
<blockquote>

## [0.2.1](https://github.com/grafana/augurs/compare/augurs-outlier-v0.2.0...augurs-outlier-v0.2.1) - 2024-06-24

### Other
- Remove unsupported .github/workflows/bencher subdirectory and old benchmark workflow ([#90](https://github.com/grafana/augurs/pull/90))
</blockquote>

## `augurs-seasons`
<blockquote>

## [0.2.1](https://github.com/grafana/augurs/compare/augurs-seasons-v0.2.0...augurs-seasons-v0.2.1) - 2024-06-24

### Other
- Remove unsupported .github/workflows/bencher subdirectory and old benchmark workflow ([#90](https://github.com/grafana/augurs/pull/90))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).