### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 documentation = "https://docs.rs/crate/augurs"
 repository = "https://github.com/grafana/augurs"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 keywords = [
   "analysis",
@@ -22,13 +22,13 @@ keywords = [
 
 [workspace.dependencies]
 
-augurs-changepoint = { version = "0.3.1", path = "crates/augurs-changepoint" }
-augurs-core = { version = "0.3.1", path = "crates/augurs-core" }
-augurs-ets = { version = "0.3.1", path = "crates/augurs-ets" }
+augurs-changepoint = { version = "0.4.0", path = "crates/augurs-changepoint" }
+augurs-core = { version = "0.4.0", path = "crates/augurs-core" }
+augurs-ets = { version = "0.4.0", path = "crates/augurs-ets" }
 augurs-forecaster = { path = "crates/augurs-forecaster" }
-augurs-mstl = { version = "0.3.1", path = "crates/augurs-mstl" }
-augurs-outlier = { version = "0.3.1", path = "crates/augurs-outlier" }
-augurs-seasons = { version = "0.3.1", path = "crates/augurs-seasons" }
+augurs-mstl = { version = "0.4.0", path = "crates/augurs-mstl" }
+augurs-outlier = { version = "0.4.0", path = "crates/augurs-outlier" }
+augurs-seasons = { version = "0.4.0", path = "crates/augurs-seasons" }
 augurs-testing = { path = "crates/augurs-testing" }
 
 distrs = "0.2.1"

--- a/crates/augurs-outlier/CHANGELOG.md
+++ b/crates/augurs-outlier/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.3.1...augurs-outlier-v0.4.0) - 2024-08-03
+
+### Fixed
+- [**breaking**] make `cluster_band` optional, undefined if no cluster is found ([#105](https://github.com/grafana/augurs/pull/105))
+
 ## [0.3.1](https://github.com/grafana/augurs/compare/augurs-outlier-v0.3.0...augurs-outlier-v0.3.1) - 2024-07-30
 
 No notable changes in this release.


### PR DESCRIPTION
## 🤖 New release
* `augurs-changepoint`: 0.3.1 -> 0.4.0
* `augurs-core`: 0.3.1 -> 0.4.0
* `augurs-testing`: 0.3.1 -> 0.4.0
* `augurs-ets`: 0.3.1 -> 0.4.0
* `augurs-mstl`: 0.3.1 -> 0.4.0
* `augurs-forecaster`: 0.3.1 -> 0.4.0
* `augurs-outlier`: 0.3.1 -> 0.4.0
* `augurs-seasons`: 0.3.1 -> 0.4.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `augurs-changepoint`
<blockquote>

## [0.3.1](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.3.0...augurs-changepoint-v0.3.1) - 2024-07-30

No notable changes in this release.
</blockquote>

## `augurs-core`
<blockquote>

## [0.3.1](https://github.com/grafana/augurs/compare/augurs-core-v0.3.0...augurs-core-v0.3.1) - 2024-07-30

No notable changes in this release.
</blockquote>

## `augurs-testing`
<blockquote>

## [0.3.1](https://github.com/grafana/augurs/compare/augurs-testing-v0.3.0...augurs-testing-v0.3.1) - 2024-07-30

No notable changes in this release.
</blockquote>

## `augurs-ets`
<blockquote>

## [0.3.1](https://github.com/grafana/augurs/compare/augurs-ets-v0.3.0...augurs-ets-v0.3.1) - 2024-07-30

No notable changes in this release.
</blockquote>

## `augurs-mstl`
<blockquote>

## [0.3.1](https://github.com/grafana/augurs/compare/augurs-mstl-v0.3.0...augurs-mstl-v0.3.1) - 2024-07-30

No notable changes in this release.
</blockquote>

## `augurs-forecaster`
<blockquote>

## [0.3.1](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.3.0...augurs-forecaster-v0.3.1) - 2024-07-30

No notable changes in this release.
</blockquote>

## `augurs-outlier`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.3.1...augurs-outlier-v0.4.0) - 2024-08-03

### Fixed
- [**breaking**] make `cluster_band` optional, undefined if no cluster is found ([#105](https://github.com/grafana/augurs/pull/105))
</blockquote>

## `augurs-seasons`
<blockquote>

## [0.3.1](https://github.com/grafana/augurs/compare/augurs-seasons-v0.3.0...augurs-seasons-v0.3.1) - 2024-07-30

No notable changes in this release.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).