### PR TITLE
chore: release v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 documentation = "https://docs.rs/crate/augurs"
 repository = "https://github.com/grafana/augurs"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 keywords = [
   "analysis",
@@ -21,15 +21,15 @@ keywords = [
 ]
 
 [workspace.dependencies]
-augurs-changepoint = { version = "0.3.1", path = "crates/augurs-changepoint" }
-augurs-clustering = { version = "0.3.1", path = "crates/augurs-clustering" }
-augurs-core = { version = "0.3.1", path = "crates/augurs-core" }
-augurs-dtw = { version = "0.3.1", path = "crates/augurs-dtw" }
-augurs-ets = { version = "0.3.1", path = "crates/augurs-ets" }
+augurs-changepoint = { version = "0.4.0", path = "crates/augurs-changepoint" }
+augurs-clustering = { version = "0.4.0", path = "crates/augurs-clustering" }
+augurs-core = { version = "0.4.0", path = "crates/augurs-core" }
+augurs-dtw = { version = "0.4.0", path = "crates/augurs-dtw" }
+augurs-ets = { version = "0.4.0", path = "crates/augurs-ets" }
 augurs-forecaster = { path = "crates/augurs-forecaster" }
-augurs-mstl = { version = "0.3.1", path = "crates/augurs-mstl" }
-augurs-outlier = { version = "0.3.1", path = "crates/augurs-outlier" }
-augurs-seasons = { version = "0.3.1", path = "crates/augurs-seasons" }
+augurs-mstl = { version = "0.4.0", path = "crates/augurs-mstl" }
+augurs-outlier = { version = "0.4.0", path = "crates/augurs-outlier" }
+augurs-seasons = { version = "0.4.0", path = "crates/augurs-seasons" }
 augurs-testing = { path = "crates/augurs-testing" }
 
 distrs = "0.2.1"

--- a/crates/augurs-clustering/CHANGELOG.md
+++ b/crates/augurs-clustering/CHANGELOG.md
@@ -6,5 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/grafana/augurs/compare/augurs-clustering-v0.3.1...augurs-clustering-v0.4.0) - 2024-09-22
+
+### Added
+
+- add augurs-clustering crate with DBSCAN algorithm ([#100](https://github.com/grafana/augurs/pull/100))
+
 ### Other
 - Add `augurs-clustering` crate

--- a/crates/augurs-core/CHANGELOG.md
+++ b/crates/augurs-core/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/grafana/augurs/compare/augurs-core-v0.3.1...augurs-core-v0.4.0) - 2024-09-22
+
+### Added
+
+- add `augurs-dtw` crate with dynamic time warping implementation ([#98](https://github.com/grafana/augurs/pull/98))
+
 ## [0.3.1](https://github.com/grafana/augurs/compare/augurs-core-v0.3.0...augurs-core-v0.3.1) - 2024-07-30
 
 No notable changes in this release.

--- a/crates/augurs-dtw/CHANGELOG.md
+++ b/crates/augurs-dtw/CHANGELOG.md
@@ -6,5 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/grafana/augurs/compare/augurs-dtw-v0.3.1...augurs-dtw-v0.4.0) - 2024-09-22
+
+### Added
+
+- derive Clone for Dtw ([#114](https://github.com/grafana/augurs/pull/114))
+- parallel DTW calculations in augurs-js ([#111](https://github.com/grafana/augurs/pull/111))
+- add `augurs-dtw` crate with dynamic time warping implementation ([#98](https://github.com/grafana/augurs/pull/98))
+
 ### Other
 - Add `augurs-dtw` crate

--- a/crates/augurs-mstl/CHANGELOG.md
+++ b/crates/augurs-mstl/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/grafana/augurs/compare/augurs-mstl-v0.3.1...augurs-mstl-v0.4.0) - 2024-09-22
+
+### Added
+
+- add `augurs-dtw` crate with dynamic time warping implementation ([#98](https://github.com/grafana/augurs/pull/98))
+
 ## [0.3.1](https://github.com/grafana/augurs/compare/augurs-mstl-v0.3.0...augurs-mstl-v0.3.1) - 2024-07-30
 
 No notable changes in this release.

--- a/crates/augurs-outlier/CHANGELOG.md
+++ b/crates/augurs-outlier/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.3.1...augurs-outlier-v0.4.0) - 2024-09-22
+
+### Fixed
+
+- [**breaking**] make `cluster_band` optional, undefined if no cluster is found ([#105](https://github.com/grafana/augurs/pull/105))
+
 ## [0.3.1](https://github.com/grafana/augurs/compare/augurs-outlier-v0.3.0...augurs-outlier-v0.3.1) - 2024-07-30
 
 No notable changes in this release.


### PR DESCRIPTION
## 🤖 New release
* `augurs-changepoint`: 0.3.1 -> 0.4.0
* `augurs-core`: 0.3.1 -> 0.4.0 (✓ API compatible changes)
* `augurs-testing`: 0.3.1 -> 0.4.0
* `augurs-clustering`: 0.3.1 -> 0.4.0
* `augurs-dtw`: 0.3.1 -> 0.4.0
* `augurs-ets`: 0.3.1 -> 0.4.0
* `augurs-mstl`: 0.3.1 -> 0.4.0 (✓ API compatible changes)
* `augurs-forecaster`: 0.3.1 -> 0.4.0
* `augurs-outlier`: 0.3.1 -> 0.4.0 (✓ API compatible changes)
* `augurs-seasons`: 0.3.1 -> 0.4.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `augurs-changepoint`
<blockquote>

## [0.3.1](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.3.0...augurs-changepoint-v0.3.1) - 2024-07-30

No notable changes in this release.
</blockquote>

## `augurs-core`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-core-v0.3.1...augurs-core-v0.4.0) - 2024-09-22

### Added

- add `augurs-dtw` crate with dynamic time warping implementation ([#98](https://github.com/grafana/augurs/pull/98))
</blockquote>

## `augurs-testing`
<blockquote>

## [0.3.1](https://github.com/grafana/augurs/compare/augurs-testing-v0.3.0...augurs-testing-v0.3.1) - 2024-07-30

No notable changes in this release.
</blockquote>

## `augurs-clustering`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-clustering-v0.3.1...augurs-clustering-v0.4.0) - 2024-09-22

### Added

- add augurs-clustering crate with DBSCAN algorithm ([#100](https://github.com/grafana/augurs/pull/100))

### Other
- Add `augurs-clustering` crate
</blockquote>

## `augurs-dtw`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-dtw-v0.3.1...augurs-dtw-v0.4.0) - 2024-09-22

### Added

- derive Clone for Dtw ([#114](https://github.com/grafana/augurs/pull/114))
- parallel DTW calculations in augurs-js ([#111](https://github.com/grafana/augurs/pull/111))
- add `augurs-dtw` crate with dynamic time warping implementation ([#98](https://github.com/grafana/augurs/pull/98))

### Other
- Add `augurs-dtw` crate
</blockquote>

## `augurs-ets`
<blockquote>

## [0.3.1](https://github.com/grafana/augurs/compare/augurs-ets-v0.3.0...augurs-ets-v0.3.1) - 2024-07-30

No notable changes in this release.
</blockquote>

## `augurs-mstl`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-mstl-v0.3.1...augurs-mstl-v0.4.0) - 2024-09-22

### Added

- add `augurs-dtw` crate with dynamic time warping implementation ([#98](https://github.com/grafana/augurs/pull/98))
</blockquote>

## `augurs-forecaster`
<blockquote>

## [0.3.1](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.3.0...augurs-forecaster-v0.3.1) - 2024-07-30

No notable changes in this release.
</blockquote>

## `augurs-outlier`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.3.1...augurs-outlier-v0.4.0) - 2024-09-22

### Fixed

- [**breaking**] make `cluster_band` optional, undefined if no cluster is found ([#105](https://github.com/grafana/augurs/pull/105))
</blockquote>

## `augurs-seasons`
<blockquote>

## [0.3.1](https://github.com/grafana/augurs/compare/augurs-seasons-v0.3.0...augurs-seasons-v0.3.1) - 2024-07-30

No notable changes in this release.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).