### PR TITLE
fix!: add serde derives for more types

### DIFF
--- a/crates/augurs-core/src/distance.rs
+++ b/crates/augurs-core/src/distance.rs
@@ -17,6 +17,7 @@ impl std::error::Error for DistanceMatrixError {}
 
 /// A matrix representing the distances between pairs of items.
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DistanceMatrix {
     matrix: Vec<Vec<f64>>,
 }

--- a/crates/augurs-outlier/Cargo.toml
+++ b/crates/augurs-outlier/Cargo.toml
@@ -24,5 +24,8 @@ thiserror.workspace = true
 tinyvec = { workspace = true, features = ["std"] }
 tracing.workspace = true
 
+[dev-dependencies]
+serde_json = "1.0.128"
+
 [features]
 parallel = ["rayon"]

--- a/crates/augurs-outlier/src/dbscan.rs
+++ b/crates/augurs-outlier/src/dbscan.rs
@@ -357,7 +357,7 @@ impl SortedData {
 
 #[cfg(test)]
 mod tests {
-    use crate::{OutlierDetector, OutlierOutput};
+    use crate::{testing::flatten_intervals, OutlierDetector, OutlierOutput};
 
     use super::*;
 
@@ -516,12 +516,13 @@ mod tests {
         // in the matrix.
         for (j, series) in results.series_results.iter().enumerate() {
             let mut outlier_state = false;
-            let mut outlier_indices = series.outlier_intervals.indices.iter();
-            let mut next_idx = outlier_indices.next();
+            let outlier_indices = flatten_intervals(&series.outlier_intervals.intervals);
+            let mut iter = outlier_indices.iter();
+            let mut next_idx = iter.next();
             for (i, item) in matrix.iter_mut().enumerate() {
                 if next_idx.map_or(false, |next_idx| i >= *next_idx) {
                     outlier_state = !outlier_state;
-                    next_idx = outlier_indices.next();
+                    next_idx = iter.next();
                 }
                 item[j] = outlier_state;
             }
@@ -598,18 +599,19 @@ mod tests {
 
         assert!(results.series_results[0]
             .outlier_intervals
-            .indices
+            .intervals
             .is_empty());
         assert!(results.series_results[1]
             .outlier_intervals
-            .indices
+            .intervals
             .is_empty());
-        assert_eq!(results.series_results[2].outlier_intervals.indices[0], 40);
-        assert_eq!(results.series_results[2].outlier_intervals.indices[1], 42);
-        assert_eq!(results.series_results[2].outlier_intervals.indices[2], 140);
-        assert_eq!(results.series_results[2].outlier_intervals.indices[3], 142);
-        assert_eq!(results.series_results[2].outlier_intervals.indices[4], 240);
-        assert_eq!(results.series_results[2].outlier_intervals.indices[5], 242);
+        let indices = flatten_intervals(&results.series_results[2].outlier_intervals.intervals);
+        assert_eq!(indices[0], 40);
+        assert_eq!(indices[1], 42);
+        assert_eq!(indices[2], 140);
+        assert_eq!(indices[3], 142);
+        assert_eq!(indices[4], 240);
+        assert_eq!(indices[5], 242);
         assert!(results.cluster_band.is_some());
     }
 

--- a/crates/augurs-outlier/src/mad.rs
+++ b/crates/augurs-outlier/src/mad.rs
@@ -383,7 +383,7 @@ mod test {
     use itertools::Itertools;
     use rv::prelude::*;
 
-    use crate::{MADDetector, OutlierDetector};
+    use crate::{testing::flatten_intervals, MADDetector, OutlierDetector};
 
     use super::Medians;
 
@@ -711,8 +711,9 @@ mod test {
                     );
                     let output = result.unwrap();
                     assert_eq!(output.series_results.len(), 1, "case {} failed", tc.name);
-                    let got_intervals = &output.series_results[0].outlier_intervals.indices;
-                    assert_eq!(intervals, got_intervals, "case {} failed", tc.name);
+                    let got_intervals =
+                        flatten_intervals(&output.series_results[0].outlier_intervals.intervals);
+                    assert_eq!(intervals, &got_intervals, "case {} failed", tc.name);
                 }
                 Err(exp) => {
                     assert!(result.is_err(), "case {} failed", tc.name);

--- a/crates/augurs-outlier/src/testing.rs
+++ b/crates/augurs-outlier/src/testing.rs
@@ -1,3 +1,5 @@
+use crate::OutlierInterval;
+
 pub const SERIES: &[&[f64]] = &[
     &[
         84.57766308278907,
@@ -873,3 +875,17 @@ pub const SERIES: &[&[f64]] = &[
         90.21207715366646,
     ],
 ];
+
+/// Convert an `OutlierIntervals` to a list of indices.
+pub(crate) fn flatten_intervals(intervals: &[OutlierInterval]) -> Vec<usize> {
+    intervals
+        .iter()
+        .flat_map(|x| {
+            let mut out = vec![x.start];
+            if let Some(end) = x.end {
+                out.push(end);
+            }
+            out
+        })
+        .collect()
+}


### PR DESCRIPTION
This is a breaking change because it changes the definition of some types
so that they make more sense.

Specifically, `OutlierOutput::outlying_series` is now a `BTreeSet` to preserve
order, and `OutlierIntervals::intervals` is now a `Vec<OutlierInterval>` instead
of a `Vec<usize>`, to make it more easily usable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced `DistanceMatrix` struct with conditional serialization and deserialization support.
	- Introduced `OutlierInterval` struct for better representation of outlier intervals.
	- Added `flatten_intervals` function for streamlined processing of outlier intervals.

- **Improvements**
	- Replaced `HashSet` with `BTreeSet` for ordered outlier series.
	- Simplified outlier interval conversion logic.

- **Documentation**
	- Added `serde_json` as a development dependency for improved JSON handling in the development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->