### PR TITLE
chore: release v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 documentation = "https://docs.rs/crate/augurs"
 repository = "https://github.com/grafana/augurs"
-version = "0.3.1"
+version = "0.4.0"
 edition = "2021"
 keywords = [
   "analysis",
@@ -22,16 +22,16 @@ keywords = [
 ]
 
 [workspace.dependencies]
-augurs = { version = "0.3.1", path = "crates/augurs" }
-augurs-changepoint = { version = "0.3.1", path = "crates/augurs-changepoint" }
-augurs-clustering = { version = "0.3.1", path = "crates/augurs-clustering" }
-augurs-core = { version = "0.3.1", path = "crates/augurs-core" }
-augurs-dtw = { version = "0.3.1", path = "crates/augurs-dtw" }
-augurs-ets = { version = "0.3.1", path = "crates/augurs-ets" }
+augurs = { version = "0.4.0", path = "crates/augurs" }
+augurs-changepoint = { version = "0.4.0", path = "crates/augurs-changepoint" }
+augurs-clustering = { version = "0.4.0", path = "crates/augurs-clustering" }
+augurs-core = { version = "0.4.0", path = "crates/augurs-core" }
+augurs-dtw = { version = "0.4.0", path = "crates/augurs-dtw" }
+augurs-ets = { version = "0.4.0", path = "crates/augurs-ets" }
 augurs-forecaster = { path = "crates/augurs-forecaster" }
-augurs-mstl = { version = "0.3.1", path = "crates/augurs-mstl" }
-augurs-outlier = { version = "0.3.1", path = "crates/augurs-outlier" }
-augurs-seasons = { version = "0.3.1", path = "crates/augurs-seasons" }
+augurs-mstl = { version = "0.4.0", path = "crates/augurs-mstl" }
+augurs-outlier = { version = "0.4.0", path = "crates/augurs-outlier" }
+augurs-seasons = { version = "0.4.0", path = "crates/augurs-seasons" }
 augurs-testing = { path = "crates/augurs-testing" }
 
 distrs = "0.2.1"

--- a/crates/augurs-changepoint/CHANGELOG.md
+++ b/crates/augurs-changepoint/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.3.1...augurs-changepoint-v0.4.0) - 2024-09-25
+
+### Added
+
+- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
+
 ## [0.3.1](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.3.0...augurs-changepoint-v0.3.1) - 2024-07-30
 
 No notable changes in this release.

--- a/crates/augurs-core/CHANGELOG.md
+++ b/crates/augurs-core/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/grafana/augurs/compare/augurs-core-v0.3.1...augurs-core-v0.4.0) - 2024-09-25
+
+### Added
+
+- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
+- add 'Forecast::chain' method to chain two forecasts together ([#115](https://github.com/grafana/augurs/pull/115))
+- add `augurs-dtw` crate with dynamic time warping implementation ([#98](https://github.com/grafana/augurs/pull/98))
+
+### Fixed
+
+- [**breaking**] add serde derives for more types ([#112](https://github.com/grafana/augurs/pull/112))
+
 ## [0.3.1](https://github.com/grafana/augurs/compare/augurs-core-v0.3.0...augurs-core-v0.3.1) - 2024-07-30
 
 No notable changes in this release.

--- a/crates/augurs-dtw/CHANGELOG.md
+++ b/crates/augurs-dtw/CHANGELOG.md
@@ -6,5 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/grafana/augurs/compare/augurs-dtw-v0.3.1...augurs-dtw-v0.4.0) - 2024-09-25
+
+### Added
+
+- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
+- derive Clone for Dtw ([#114](https://github.com/grafana/augurs/pull/114))
+- parallel DTW calculations in augurs-js ([#111](https://github.com/grafana/augurs/pull/111))
+- add `augurs-dtw` crate with dynamic time warping implementation ([#98](https://github.com/grafana/augurs/pull/98))
+
 ### Other
 - Add `augurs-dtw` crate

--- a/crates/augurs-ets/CHANGELOG.md
+++ b/crates/augurs-ets/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/grafana/augurs/compare/augurs-ets-v0.3.1...augurs-ets-v0.4.0) - 2024-09-25
+
+### Added
+
+- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
+
 ## [0.3.1](https://github.com/grafana/augurs/compare/augurs-ets-v0.3.0...augurs-ets-v0.3.1) - 2024-07-30
 
 No notable changes in this release.

--- a/crates/augurs-ets/CHANGELOG.md
+++ b/crates/augurs-ets/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
 
+### Removed
+
+- Remove `data` module from `augurs-ets` crate ([#117](https://github.com/grafana/augurs/pull/117))
+
 ## [0.3.1](https://github.com/grafana/augurs/compare/augurs-ets-v0.3.0...augurs-ets-v0.3.1) - 2024-07-30
 
 No notable changes in this release.

--- a/crates/augurs-forecaster/CHANGELOG.md
+++ b/crates/augurs-forecaster/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.3.1...augurs-forecaster-v0.4.0) - 2024-09-25
+
+### Added
+
+- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
+
+### Fixed
+
+- fix invalid lifetime warning on nightly ([#113](https://github.com/grafana/augurs/pull/113))
+
 ## [0.3.1](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.3.0...augurs-forecaster-v0.3.1) - 2024-07-30
 
 No notable changes in this release.

--- a/crates/augurs-mstl/CHANGELOG.md
+++ b/crates/augurs-mstl/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/grafana/augurs/compare/augurs-mstl-v0.3.1...augurs-mstl-v0.4.0) - 2024-09-25
+
+### Added
+
+- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
+- add `augurs-dtw` crate with dynamic time warping implementation ([#98](https://github.com/grafana/augurs/pull/98))
+
 ## [0.3.1](https://github.com/grafana/augurs/compare/augurs-mstl-v0.3.0...augurs-mstl-v0.3.1) - 2024-07-30
 
 No notable changes in this release.

--- a/crates/augurs-outlier/CHANGELOG.md
+++ b/crates/augurs-outlier/CHANGELOG.md
@@ -11,11 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
+- export the data types used by MAD and DBSCAN detectors ([#117](https://github.com/grafana/augurs/pull/117))
 
 ### Fixed
 
 - [**breaking**] add serde derives for more types ([#112](https://github.com/grafana/augurs/pull/112))
 - [**breaking**] make `cluster_band` optional, undefined if no cluster is found ([#105](https://github.com/grafana/augurs/pull/105))
+
+### Changed
+
+- rename `DBSCANDetector` to `DbscanDetector` ([#117](https://github.com/grafana/augurs/pull/117))
+- `DbscanDetector::parallelize` now takes self by value rather than mutable reference to encourage chaining ([#117](https://github.com/grafana/augurs/pull/117))
 
 ## [0.3.1](https://github.com/grafana/augurs/compare/augurs-outlier-v0.3.0...augurs-outlier-v0.3.1) - 2024-07-30
 

--- a/crates/augurs-outlier/CHANGELOG.md
+++ b/crates/augurs-outlier/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.3.1...augurs-outlier-v0.4.0) - 2024-09-25
+
+### Added
+
+- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
+
+### Fixed
+
+- [**breaking**] add serde derives for more types ([#112](https://github.com/grafana/augurs/pull/112))
+- [**breaking**] make `cluster_band` optional, undefined if no cluster is found ([#105](https://github.com/grafana/augurs/pull/105))
+
 ## [0.3.1](https://github.com/grafana/augurs/compare/augurs-outlier-v0.3.0...augurs-outlier-v0.3.1) - 2024-07-30
 
 No notable changes in this release.

--- a/crates/augurs-seasons/CHANGELOG.md
+++ b/crates/augurs-seasons/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/grafana/augurs/compare/augurs-seasons-v0.3.1...augurs-seasons-v0.4.0) - 2024-09-25
+
+### Added
+
+- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
+
 ## [0.3.1](https://github.com/grafana/augurs/compare/augurs-seasons-v0.3.0...augurs-seasons-v0.3.1) - 2024-07-30
 
 No notable changes in this release.

--- a/crates/augurs-testing/CHANGELOG.md
+++ b/crates/augurs-testing/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/grafana/augurs/compare/augurs-testing-v0.3.1...augurs-testing-v0.4.0) - 2024-09-25
+
+### Added
+
+- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
+
 ## [0.3.1](https://github.com/grafana/augurs/compare/augurs-testing-v0.3.0...augurs-testing-v0.3.1) - 2024-07-30
 
 No notable changes in this release.

--- a/crates/augurs/CHANGELOG.md
+++ b/crates/augurs/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
@@ -6,12 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.0](https://github.com/grafana/augurs/compare/augurs-clustering-v0.3.1...augurs-clustering-v0.4.0) - 2024-09-25
+## [0.4.0](https://github.com/grafana/augurs/compare/augurs-v0.3.1...augurs-v0.4.0) - 2024-09-25
 
 ### Added
 
 - add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
-- add augurs-clustering crate with DBSCAN algorithm ([#100](https://github.com/grafana/augurs/pull/100))
-
-### Other
-- Add `augurs-clustering` crate


### PR DESCRIPTION
## 🤖 New release
* `augurs`: 0.3.1 -> 0.4.0
* `augurs-changepoint`: 0.3.1 -> 0.4.0 (✓ API compatible changes)
* `augurs-core`: 0.3.1 -> 0.4.0 (✓ API compatible changes)
* `augurs-testing`: 0.3.1 -> 0.4.0 (✓ API compatible changes)
* `augurs-clustering`: 0.3.1 -> 0.4.0
* `augurs-dtw`: 0.3.1 -> 0.4.0
* `augurs-ets`: 0.3.1 -> 0.4.0 (⚠️ API breaking changes)
* `augurs-mstl`: 0.3.1 -> 0.4.0 (✓ API compatible changes)
* `augurs-forecaster`: 0.3.1 -> 0.4.0 (✓ API compatible changes)
* `augurs-outlier`: 0.3.1 -> 0.4.0 (⚠️ API breaking changes)
* `augurs-seasons`: 0.3.1 -> 0.4.0 (✓ API compatible changes)

### ⚠️ `augurs-ets` breaking changes

```
--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/module_missing.ron

Failed in:
  mod augurs_ets::data, previously in file /tmp/.tmpUwRTP0/augurs-ets/src/data.rs:1

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing, renamed, or changed from const to static.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  AUSTRES in file /tmp/.tmpUwRTP0/augurs-ets/src/data.rs:22
  AIR_PASSENGERS in file /tmp/.tmpUwRTP0/augurs-ets/src/data.rs:7
```

### ⚠️ `augurs-outlier` breaking changes

```
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/struct_missing.ron

Failed in:
  struct augurs_outlier::DBSCANDetector, previously in file /tmp/.tmpUwRTP0/augurs-outlier/src/dbscan.rs:46

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.35.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field indices of struct OutlierIntervals, previously in file /tmp/.tmpUwRTP0/augurs-outlier/src/lib.rs:129
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `augurs`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-v0.3.1...augurs-v0.4.0) - 2024-09-25

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
</blockquote>

## `augurs-changepoint`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.3.1...augurs-changepoint-v0.4.0) - 2024-09-25

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
</blockquote>

## `augurs-core`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-core-v0.3.1...augurs-core-v0.4.0) - 2024-09-25

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
- add 'Forecast::chain' method to chain two forecasts together ([#115](https://github.com/grafana/augurs/pull/115))
- add `augurs-dtw` crate with dynamic time warping implementation ([#98](https://github.com/grafana/augurs/pull/98))

### Fixed

- [**breaking**] add serde derives for more types ([#112](https://github.com/grafana/augurs/pull/112))
</blockquote>

## `augurs-testing`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-testing-v0.3.1...augurs-testing-v0.4.0) - 2024-09-25

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
</blockquote>

## `augurs-clustering`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-clustering-v0.3.1...augurs-clustering-v0.4.0) - 2024-09-25

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
- add augurs-clustering crate with DBSCAN algorithm ([#100](https://github.com/grafana/augurs/pull/100))

### Other
- Add `augurs-clustering` crate
</blockquote>

## `augurs-dtw`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-dtw-v0.3.1...augurs-dtw-v0.4.0) - 2024-09-25

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
- derive Clone for Dtw ([#114](https://github.com/grafana/augurs/pull/114))
- parallel DTW calculations in augurs-js ([#111](https://github.com/grafana/augurs/pull/111))
- add `augurs-dtw` crate with dynamic time warping implementation ([#98](https://github.com/grafana/augurs/pull/98))

### Other
- Add `augurs-dtw` crate
</blockquote>

## `augurs-ets`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-ets-v0.3.1...augurs-ets-v0.4.0) - 2024-09-25

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
</blockquote>

## `augurs-mstl`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-mstl-v0.3.1...augurs-mstl-v0.4.0) - 2024-09-25

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
- add `augurs-dtw` crate with dynamic time warping implementation ([#98](https://github.com/grafana/augurs/pull/98))
</blockquote>

## `augurs-forecaster`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.3.1...augurs-forecaster-v0.4.0) - 2024-09-25

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))

### Fixed

- fix invalid lifetime warning on nightly ([#113](https://github.com/grafana/augurs/pull/113))
</blockquote>

## `augurs-outlier`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.3.1...augurs-outlier-v0.4.0) - 2024-09-25

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))

### Fixed

- [**breaking**] add serde derives for more types ([#112](https://github.com/grafana/augurs/pull/112))
- [**breaking**] make `cluster_band` optional, undefined if no cluster is found ([#105](https://github.com/grafana/augurs/pull/105))
</blockquote>

## `augurs-seasons`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-seasons-v0.3.1...augurs-seasons-v0.4.0) - 2024-09-25

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new convenience crate named 'augurs' that re-exports other crates for easier access.
	- Added the `Forecast::chain` method for chaining forecasts together.
	- Implemented dynamic time warping in the new `augurs-dtw` crate.
	- Enhanced usability with the `Clone` trait for the `Dtw` type.
	- Removed the `data` module from the `augurs-ets` crate.
	- Made the `cluster_band` parameter optional in the relevant functions.

- **Bug Fixes**
	- Addressed an invalid lifetime warning in the `augurs-forecaster` crate.

- **Documentation**
	- Updated changelogs for all affected crates to reflect the new version and features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->