### PR TITLE
ci: run Rust CI workflow on PRs to non-main bases

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated workflow configuration for Rust by removing the `pull_request` trigger for the `main` branch, now only responding to `push` events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->