### PR TITLE
chore: release v0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 documentation = "https://docs.rs/crate/augurs"
 repository = "https://github.com/grafana/augurs"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 keywords = [
   "analysis",
@@ -23,16 +23,16 @@ keywords = [
 
 [workspace.dependencies]
 augurs = { path = "crates/augurs" }
-augurs-changepoint = { version = "0.4.0", path = "crates/augurs-changepoint" }
-augurs-clustering = { version = "0.4.0", path = "crates/augurs-clustering" }
-augurs-core = { version = "0.4.0", path = "crates/augurs-core" }
-augurs-dtw = { version = "0.4.0", path = "crates/augurs-dtw" }
-augurs-ets = { version = "0.4.0", path = "crates/augurs-ets" }
-augurs-forecaster = { version = "0.4.0", path = "crates/augurs-forecaster" }
-augurs-mstl = { version = "0.4.0", path = "crates/augurs-mstl" }
-augurs-outlier = { version = "0.4.0", path = "crates/augurs-outlier" }
-augurs-prophet = { version = "0.4.0", path = "crates/augurs-prophet" }
-augurs-seasons = { version = "0.4.0", path = "crates/augurs-seasons" }
+augurs-changepoint = { version = "0.4.1", path = "crates/augurs-changepoint" }
+augurs-clustering = { version = "0.4.1", path = "crates/augurs-clustering" }
+augurs-core = { version = "0.4.1", path = "crates/augurs-core" }
+augurs-dtw = { version = "0.4.1", path = "crates/augurs-dtw" }
+augurs-ets = { version = "0.4.1", path = "crates/augurs-ets" }
+augurs-forecaster = { version = "0.4.1", path = "crates/augurs-forecaster" }
+augurs-mstl = { version = "0.4.1", path = "crates/augurs-mstl" }
+augurs-outlier = { version = "0.4.1", path = "crates/augurs-outlier" }
+augurs-prophet = { version = "0.4.1", path = "crates/augurs-prophet" }
+augurs-seasons = { version = "0.4.1", path = "crates/augurs-seasons" }
 augurs-testing = { path = "crates/augurs-testing" }
 
 anyhow = "1.0.89"

--- a/crates/augurs-prophet/CHANGELOG.md
+++ b/crates/augurs-prophet/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/grafana/augurs/compare/augurs-prophet-v0.4.0...augurs-prophet-v0.4.1) - 2024-10-16
+
+### Fixed
+
+- fix several issues with JS bindings ([#131](https://github.com/grafana/augurs/pull/131))
+
 ## [0.4.0](https://github.com/grafana/augurs/compare/augurs-prophet-v0.3.1...augurs-prophet-v0.4.0) - 2024-10-16
 
 ### Added

--- a/crates/augurs/CHANGELOG.md
+++ b/crates/augurs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1](https://github.com/grafana/augurs/compare/augurs-v0.4.0...augurs-v0.4.1) - 2024-10-16
+
+### Fixed
+
+- specify all-features=true for docs.rs
+
 ## [0.4.0](https://github.com/grafana/augurs/compare/augurs-v0.3.1...augurs-v0.4.0) - 2024-10-16
 
 ### Added


### PR DESCRIPTION
## 🤖 New release
* `augurs`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `augurs-changepoint`: 0.4.0 -> 0.4.1
* `augurs-core`: 0.4.0 -> 0.4.1
* `augurs-clustering`: 0.4.0 -> 0.4.1
* `augurs-dtw`: 0.4.0 -> 0.4.1
* `augurs-ets`: 0.4.0 -> 0.4.1
* `augurs-mstl`: 0.4.0 -> 0.4.1
* `augurs-forecaster`: 0.4.0 -> 0.4.1
* `augurs-outlier`: 0.4.0 -> 0.4.1
* `augurs-prophet`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `augurs-seasons`: 0.4.0 -> 0.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `augurs`
<blockquote>

## [0.4.1](https://github.com/grafana/augurs/compare/augurs-v0.4.0...augurs-v0.4.1) - 2024-10-16

### Fixed

- specify all-features=true for docs.rs
</blockquote>

## `augurs-changepoint`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.3.1...augurs-changepoint-v0.4.0) - 2024-10-16

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
</blockquote>

## `augurs-core`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-core-v0.3.1...augurs-core-v0.4.0) - 2024-10-16

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
- add 'Forecast::chain' method to chain two forecasts together ([#115](https://github.com/grafana/augurs/pull/115))
- add `augurs-dtw` crate with dynamic time warping implementation ([#98](https://github.com/grafana/augurs/pull/98))

### Fixed

- [**breaking**] add serde derives for more types ([#112](https://github.com/grafana/augurs/pull/112))
</blockquote>

## `augurs-clustering`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-clustering-v0.3.1...augurs-clustering-v0.4.0) - 2024-10-16

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
- add augurs-clustering crate with DBSCAN algorithm ([#100](https://github.com/grafana/augurs/pull/100))

### Other
- Add `augurs-clustering` crate
</blockquote>

## `augurs-dtw`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-dtw-v0.3.1...augurs-dtw-v0.4.0) - 2024-10-16

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
- derive Clone for Dtw ([#114](https://github.com/grafana/augurs/pull/114))
- parallel DTW calculations in augurs-js ([#111](https://github.com/grafana/augurs/pull/111))
- add `augurs-dtw` crate with dynamic time warping implementation ([#98](https://github.com/grafana/augurs/pull/98))

### Other
- Add `augurs-dtw` crate
</blockquote>

## `augurs-ets`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-ets-v0.3.1...augurs-ets-v0.4.0) - 2024-10-16

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))

### Other

- Add Prophet algorithm in `augurs-prophet` crate ([#118](https://github.com/grafana/augurs/pull/118))
</blockquote>

## `augurs-mstl`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-mstl-v0.3.1...augurs-mstl-v0.4.0) - 2024-10-16

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))
- add `augurs-dtw` crate with dynamic time warping implementation ([#98](https://github.com/grafana/augurs/pull/98))
</blockquote>

## `augurs-forecaster`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.3.1...augurs-forecaster-v0.4.0) - 2024-10-16

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))

### Fixed

- fix invalid lifetime warning on nightly ([#113](https://github.com/grafana/augurs/pull/113))
</blockquote>

## `augurs-outlier`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.3.1...augurs-outlier-v0.4.0) - 2024-10-16

### Added

- add cmdstan-based optimizer for augurs-prophet ([#121](https://github.com/grafana/augurs/pull/121))
- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))

### Fixed

- [**breaking**] add serde derives for more types ([#112](https://github.com/grafana/augurs/pull/112))
- [**breaking**] make `cluster_band` optional, undefined if no cluster is found ([#105](https://github.com/grafana/augurs/pull/105))

### Other

- Add Prophet algorithm in `augurs-prophet` crate ([#118](https://github.com/grafana/augurs/pull/118))
</blockquote>

## `augurs-prophet`
<blockquote>

## [0.4.1](https://github.com/grafana/augurs/compare/augurs-prophet-v0.4.0...augurs-prophet-v0.4.1) - 2024-10-16

### Fixed

- fix several issues with JS bindings ([#131](https://github.com/grafana/augurs/pull/131))
</blockquote>

## `augurs-seasons`
<blockquote>

## [0.4.0](https://github.com/grafana/augurs/compare/augurs-seasons-v0.3.1...augurs-seasons-v0.4.0) - 2024-10-16

### Added

- add 'augurs' convenience crate, re-exporting other crates ([#117](https://github.com/grafana/augurs/pull/117))

### Other

- Add Prophet algorithm in `augurs-prophet` crate ([#118](https://github.com/grafana/augurs/pull/118))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Version 0.4.1 released, enhancing dependency management and introducing fixes for JavaScript bindings in `augurs-prophet`.
	- Added cmdstan-based optimizer and improved functionality in `augurs-prophet`.
  
- **Bug Fixes**
	- Resolved issues related to JavaScript bindings in the latest version of `augurs-prophet`.

- **Documentation**
	- Updated changelogs for `augurs` and `augurs-prophet` to reflect new features and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->