### PR TITLE
chore: define lints in Cargo.toml instead of each crate's lib.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,15 @@ iai = "0.1.1"
 pprof = { version = "0.13.0", features = ["criterion", "frame-pointer", "prost-codec"] }
 pretty_assertions = "1.4.1"
 
+[workspace.lints.rust]
+missing_debug_implementations = "warn"
+missing_docs = "warn"
+rust_2018_idioms = "warn"
+# Allow `non_local_definitions` until https://github.com/rust-lang/rust/issues/131643
+# is resolved.
+non_local_definitions = { level = "allow", priority = 1 }
+unreachable_pub = "warn"
+
 # See https://nnethercote.github.io/perf-book/build-configuration.html
 # for more information on why we're using these settings.
 [profile.release]

--- a/crates/augurs-changepoint/Cargo.toml
+++ b/crates/augurs-changepoint/Cargo.toml
@@ -34,3 +34,6 @@ augurs-testing.workspace = true
 criterion.workspace = true
 iai.workspace = true
 pprof.workspace = true
+
+[lints]
+workspace = true

--- a/crates/augurs-changepoint/src/lib.rs
+++ b/crates/augurs-changepoint/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![warn(missing_docs)]
 use std::{fmt, num::NonZeroUsize};
 
 pub use changepoint::rv::{dist, process::gaussian::kernel};
@@ -144,6 +143,7 @@ impl Default for DefaultArgpcpDetector {
 }
 
 /// Builder for a [`DefaultArgpcpDetector`].
+#[derive(Debug, Clone)]
 pub struct DefaultArgpcpDetectorBuilder {
     constant_value: f64,
     length_scale: f64,

--- a/crates/augurs-clustering/Cargo.toml
+++ b/crates/augurs-clustering/Cargo.toml
@@ -22,3 +22,6 @@ bench = false
 [[bench]]
 name = "dbscan"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/augurs-clustering/src/lib.rs
+++ b/crates/augurs-clustering/src/lib.rs
@@ -1,10 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
 
 use std::collections::VecDeque;
 

--- a/crates/augurs-core/Cargo.toml
+++ b/crates/augurs-core/Cargo.toml
@@ -14,3 +14,6 @@ bench = false
 
 [dependencies]
 serde = { version = "1.0.166", optional = true, features = ["derive"] }
+
+[lints]
+workspace = true

--- a/crates/augurs-core/src/lib.rs
+++ b/crates/augurs-core/src/lib.rs
@@ -1,10 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
 
 /// Common traits and types for time series forecasting models.
 pub mod prelude {

--- a/crates/augurs-dtw/Cargo.toml
+++ b/crates/augurs-dtw/Cargo.toml
@@ -28,3 +28,6 @@ bench = false
 [[bench]]
 name = "dtw"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/augurs-dtw/src/lib.rs
+++ b/crates/augurs-dtw/src/lib.rs
@@ -1,10 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
 
 use augurs_core::DistanceMatrix;
 

--- a/crates/augurs-ets/Cargo.toml
+++ b/crates/augurs-ets/Cargo.toml
@@ -43,3 +43,6 @@ harness = false
 [[bench]]
 name = "air_passengers_iai"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/augurs-ets/src/ets.rs
+++ b/crates/augurs-ets/src/ets.rs
@@ -7,7 +7,7 @@ const TOLERANCE: f64 = 1e-10;
 const HUGEN: f64 = 1e10;
 
 #[derive(Debug, Clone)]
-pub struct FitState {
+pub(crate) struct FitState {
     x: Vec<f64>,
     params: Params,
     lik: f64,
@@ -29,13 +29,13 @@ pub struct FitState {
 impl FitState {
     /// The likelihood of the model, given the data.
     #[inline]
-    pub fn likelihood(&self) -> f64 {
+    pub(crate) fn likelihood(&self) -> f64 {
         self.lik
     }
 
     /// The mean squared error (MSE) of the model.
     #[inline]
-    pub fn mse(&self) -> f64 {
+    pub(crate) fn mse(&self) -> f64 {
         self.amse[0]
     }
 
@@ -43,19 +43,19 @@ impl FitState {
     ///
     /// This is the average of the MSE over the number of forecasting horizons (`nmse`).
     #[inline]
-    pub fn amse(&self) -> f64 {
+    pub(crate) fn amse(&self) -> f64 {
         self.amse.iter().sum::<f64>() / self.amse.len() as f64
     }
 
     #[inline]
-    pub fn sigma_squared(&self) -> f64 {
+    pub(crate) fn sigma_squared(&self) -> f64 {
         self.residuals.iter().map(|e| e.powi(2)).sum::<f64>()
             / (self.residuals.len() as f64 - self.n_params as f64 - 2.0)
     }
 
     /// The mean absolute error (MAE) of the model.
     #[inline]
-    pub fn mae(&self) -> f64 {
+    pub(crate) fn mae(&self) -> f64 {
         self.residuals.iter().map(|e| e.abs()).sum::<f64>() / self.residuals.len() as f64
     }
 
@@ -63,7 +63,7 @@ impl FitState {
     ///
     /// Each element is a slice of length `n_states` containing the level,
     /// growth and seasonal parameters of the model.
-    pub fn states(&self) -> impl Iterator<Item = &[f64]> {
+    pub(crate) fn states(&self) -> impl Iterator<Item = &[f64]> {
         self.x.chunks_exact(self.n_states)
     }
 
@@ -71,31 +71,31 @@ impl FitState {
     ///
     /// This should be the best value found while fitting the model,
     /// after which training stopped.
-    pub fn last_state(&self) -> &[f64] {
+    pub(crate) fn last_state(&self) -> &[f64] {
         self.states().last().unwrap()
     }
 
     /// The parameters used when fitting the model.
     #[inline]
-    pub fn params(&self) -> &Params {
+    pub(crate) fn params(&self) -> &Params {
         &self.params
     }
 
     /// The number of parameters used when fitting the model.
     #[inline]
-    pub fn n_params(&self) -> usize {
+    pub(crate) fn n_params(&self) -> usize {
         self.n_params
     }
 
     /// The residuals of the model against the training data.
     #[inline]
-    pub fn residuals(&self) -> &[f64] {
+    pub(crate) fn residuals(&self) -> &[f64] {
         &self.residuals
     }
 
     /// The fitted values of the model.
     #[inline]
-    pub fn fitted(&self) -> &[f64] {
+    pub(crate) fn fitted(&self) -> &[f64] {
         &self.fitted
     }
 }
@@ -105,7 +105,7 @@ impl FitState {
 /// This includes everything specified by the user, but not the state of the
 /// model (which is stored in [`FitState`]).
 #[derive(Debug, Clone)]
-pub struct Ets {
+pub(crate) struct Ets {
     pub model_type: ModelType,
     #[allow(dead_code)] // unused for now as seasonal models are unimplemented.
     pub season_length: usize,

--- a/crates/augurs-ets/src/lib.rs
+++ b/crates/augurs-ets/src/lib.rs
@@ -22,7 +22,6 @@
 //! ```
 //!
 //! [statsforecast]: https://nixtla.github.io/statsforecast/models.html#autoets
-#![warn(missing_docs)]
 
 mod auto;
 mod ets;

--- a/crates/augurs-ets/src/model.rs
+++ b/crates/augurs-ets/src/model.rs
@@ -299,7 +299,7 @@ pub(crate) struct OptimizeParams {
 }
 
 impl OptimizeParams {
-    pub fn n_included(&self) -> usize {
+    pub(crate) fn n_included(&self) -> usize {
         self.alpha as usize + self.beta as usize + self.gamma as usize + self.phi as usize
     }
 }
@@ -1225,7 +1225,7 @@ impl Predict for Model {
 
 struct Forecast<'a>(&'a mut augurs_core::Forecast);
 
-impl<'a> Forecast<'a> {
+impl Forecast<'_> {
     /// Calculate the prediction intervals for the forecast.
     fn calculate_intervals(&mut self, ets: &Ets, fit: &FitState, horizon: usize, level: f64) {
         let sigma = fit.sigma_squared();

--- a/crates/augurs-ets/src/stat.rs
+++ b/crates/augurs-ets/src/stat.rs
@@ -1,4 +1,4 @@
-pub trait VarExt {
+pub(crate) trait VarExt {
     fn var(&self, ddof: usize) -> f64;
     fn std(&self, ddof: usize) -> f64 {
         self.var(ddof).sqrt()

--- a/crates/augurs-forecaster/Cargo.toml
+++ b/crates/augurs-forecaster/Cargo.toml
@@ -20,3 +20,6 @@ thiserror.workspace = true
 [dev-dependencies]
 augurs.workspace = true
 augurs-testing.workspace = true
+
+[lints]
+workspace = true

--- a/crates/augurs-forecaster/src/lib.rs
+++ b/crates/augurs-forecaster/src/lib.rs
@@ -1,10 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
 
 mod data;
 mod error;

--- a/crates/augurs-js/Cargo.toml
+++ b/crates/augurs-js/Cargo.toml
@@ -48,3 +48,6 @@ wasm-tracing = { version = "0.2.1", optional = true }
 [package.metadata.wasm-pack.profile.release]
 # previously had just ['-O4']
 wasm-opt = ['-O4', '--enable-bulk-memory', '--enable-threads']
+
+[lints]
+workspace = true

--- a/crates/augurs-js/src/lib.rs
+++ b/crates/augurs-js/src/lib.rs
@@ -2,12 +2,6 @@
 // Annoying, hopefully https://github.com/madonoharu/tsify/issues/42 will
 // be resolved at some point.
 #![allow(non_snake_case, clippy::empty_docs)]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
 
 use serde::Serialize;
 use tsify_next::Tsify;

--- a/crates/augurs-mstl/Cargo.toml
+++ b/crates/augurs-mstl/Cargo.toml
@@ -35,3 +35,6 @@ harness = false
 [[bench]]
 name = "vic_elec_iai"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/augurs-mstl/src/lib.rs
+++ b/crates/augurs-mstl/src/lib.rs
@@ -1,10 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
 
 use stlrs::MstlResult;
 use tracing::instrument;

--- a/crates/augurs-outlier/Cargo.toml
+++ b/crates/augurs-outlier/Cargo.toml
@@ -30,3 +30,6 @@ serde_json.workspace = true
 
 [features]
 parallel = ["rayon"]
+
+[lints]
+workspace = true

--- a/crates/augurs-outlier/src/dbscan.rs
+++ b/crates/augurs-outlier/src/dbscan.rs
@@ -255,7 +255,7 @@ impl DbscanDetector {
     }
 }
 
-pub struct DBScan1DResults {
+pub(crate) struct DBScan1DResults {
     cluster_min: Option<f64>,
     cluster_max: Option<f64>,
     outlier_indices: TinyVec<[Index; 24]>,
@@ -368,7 +368,7 @@ mod tests {
     // Transposed dataset for testing DBSCAN.
     // There are 13 timestamps and 9 series: each inner
     // array contains the values for the all series at that timestamp.
-    pub static DBSCAN_DATASET: &[&[f64]] = &[
+    static DBSCAN_DATASET: &[&[f64]] = &[
         // all in cluster if eps<=1
         &[1., 2., 3., 4., 5., 6., 7., 8., 9.],
         // all anomalous unless eps>=3

--- a/crates/augurs-outlier/src/lib.rs
+++ b/crates/augurs-outlier/src/lib.rs
@@ -1,5 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![warn(missing_docs)]
 
 use std::collections::BTreeSet;
 

--- a/crates/augurs-outlier/src/mad.rs
+++ b/crates/augurs-outlier/src/mad.rs
@@ -500,7 +500,7 @@ mod test {
         lower.into_iter().interleave(upper).collect()
     }
 
-    const MAD_TEST_CASES: &[MADTestCase] = &[
+    const MAD_TEST_CASES: &[MADTestCase<'_>] = &[
         MADTestCase {
             name: "normal",
             data: BASE_SAMPLE,
@@ -618,7 +618,7 @@ mod test {
         },
     ];
 
-    fn test_calculate_mad(tc: &MADTestCase) {
+    fn test_calculate_mad(tc: &MADTestCase<'_>) {
         let mad = MADDetector::with_sensitivity(0.5).unwrap();
         let result = tc
             .precalculated_medians

--- a/crates/augurs-outlier/src/sensitivity.rs
+++ b/crates/augurs-outlier/src/sensitivity.rs
@@ -13,7 +13,7 @@
 /// Crucially, though, sensitivity will always be a value between 0.0
 /// and 1.0 to make it easier to reason about for users.
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd)]
-pub struct Sensitivity(pub f64);
+pub(crate) struct Sensitivity(pub f64);
 
 impl TryFrom<f64> for Sensitivity {
     type Error = SensitivityError;

--- a/crates/augurs-outlier/src/testing.rs
+++ b/crates/augurs-outlier/src/testing.rs
@@ -1,6 +1,6 @@
 use crate::OutlierInterval;
 
-pub const SERIES: &[&[f64]] = &[
+pub(crate) const SERIES: &[&[f64]] = &[
     &[
         84.57766308278907,
         1.4076132246566786,

--- a/crates/augurs-prophet/Cargo.toml
+++ b/crates/augurs-prophet/Cargo.toml
@@ -49,3 +49,6 @@ serde = ["dep:serde"]
 name = "download-stan-model"
 path = "src/bin/main.rs"
 required-features = ["download"]
+
+[lints]
+workspace = true

--- a/crates/augurs-prophet/build.rs
+++ b/crates/augurs-prophet/build.rs
@@ -1,3 +1,5 @@
+//! Build script for the Prophet model.
+
 /// Compile the Prophet model (in prophet.stan) to a binary,
 /// using the Makefile in the cmdstan installation.
 ///

--- a/crates/augurs-prophet/src/lib.rs
+++ b/crates/augurs-prophet/src/lib.rs
@@ -1,10 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
 mod data;
 mod error;
 mod features;

--- a/crates/augurs-seasons/Cargo.toml
+++ b/crates/augurs-seasons/Cargo.toml
@@ -28,3 +28,6 @@ pprof.workspace = true
 [[bench]]
 name = "periodogram"
 harness = false
+
+[lints]
+workspace = true

--- a/crates/augurs-seasons/src/lib.rs
+++ b/crates/augurs-seasons/src/lib.rs
@@ -1,11 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
-
 mod periodogram;
 #[cfg(test)]
 mod test_data;

--- a/crates/augurs-testing/Cargo.toml
+++ b/crates/augurs-testing/Cargo.toml
@@ -16,3 +16,6 @@ bench = false
 [dependencies]
 assert_approx_eq = "1.1.0"
 once_cell = "1.18.0"
+
+[lints]
+workspace = true

--- a/crates/augurs-testing/src/lib.rs
+++ b/crates/augurs-testing/src/lib.rs
@@ -3,12 +3,6 @@
 //! Eventually I'd like this to be a fully fledged testing harness to automatically
 //! compare results between the augurs, Python and R implementations, but for now
 //! it's just a place to put some data.
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
 
 pub mod data;
 

--- a/crates/augurs/Cargo.toml
+++ b/crates/augurs/Cargo.toml
@@ -43,3 +43,6 @@ prophet-cmdstan = ["augurs-prophet/cmdstan"]
 prophet-compile-cmdstan = ["augurs-prophet/compile-cmdstan"]
 outlier = ["augurs-outlier"]
 seasons = ["augurs-seasons"]
+
+[lints]
+workspace = true

--- a/crates/augurs/src/lib.rs
+++ b/crates/augurs/src/lib.rs
@@ -1,10 +1,4 @@
 #![doc = include_str!("../README.md")]
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
 
 #[doc(inline)]
 #[cfg(feature = "changepoint")]

--- a/crates/pyaugurs/Cargo.toml
+++ b/crates/pyaugurs/Cargo.toml
@@ -29,3 +29,6 @@ augurs-seasons.workspace = true
 numpy = "0.21.0"
 pyo3 = { version = "0.21.0", features = ["extension-module"] }
 tracing = { version = "0.1.37", features = ["log"] }
+
+[lints]
+workspace = true

--- a/crates/pyaugurs/src/lib.rs
+++ b/crates/pyaugurs/src/lib.rs
@@ -4,12 +4,6 @@
 //! The documentation here is useful for understanding the Python API, however.
 //!
 //! See the crate README for information on Python API usage and installation.
-#![warn(
-    missing_docs,
-    missing_debug_implementations,
-    rust_2018_idioms,
-    unreachable_pub
-)]
 
 use numpy::{PyArray1, ToPyArray};
 use pyo3::prelude::*;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a Median Absolute Deviation (MAD) outlier detection mechanism with new structures and methods for enhanced outlier detection capabilities.
  
- **Bug Fixes**
  - Adjusted visibility of several structs and methods to improve encapsulation and restrict access as needed.

- **Documentation**
  - Removed various linting warnings related to documentation enforcement across multiple crates, which may affect code quality checks.

- **Chores**
  - Added new linting configurations to several `Cargo.toml` files, enabling workspace-level linting rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->