### PR TITLE
chore: release v0.5.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ authors = [
 ]
 documentation = "https://docs.rs/crate/augurs"
 repository = "https://github.com/grafana/augurs"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 keywords = [
   "analysis",
@@ -23,16 +23,16 @@ keywords = [
 
 [workspace.dependencies]
 augurs = { path = "crates/augurs" }
-augurs-changepoint = { version = "0.5.0", path = "crates/augurs-changepoint" }
-augurs-clustering = { version = "0.5.0", path = "crates/augurs-clustering" }
-augurs-core = { version = "0.5.0", path = "crates/augurs-core" }
-augurs-dtw = { version = "0.5.0", path = "crates/augurs-dtw" }
-augurs-ets = { version = "0.5.0", path = "crates/augurs-ets" }
-augurs-forecaster = { version = "0.5.0", path = "crates/augurs-forecaster" }
-augurs-mstl = { version = "0.5.0", path = "crates/augurs-mstl" }
-augurs-outlier = { version = "0.5.0", path = "crates/augurs-outlier" }
-augurs-prophet = { version = "0.5.0", path = "crates/augurs-prophet" }
-augurs-seasons = { version = "0.5.0", path = "crates/augurs-seasons" }
+augurs-changepoint = { version = "0.5.1", path = "crates/augurs-changepoint" }
+augurs-clustering = { version = "0.5.1", path = "crates/augurs-clustering" }
+augurs-core = { version = "0.5.1", path = "crates/augurs-core" }
+augurs-dtw = { version = "0.5.1", path = "crates/augurs-dtw" }
+augurs-ets = { version = "0.5.1", path = "crates/augurs-ets" }
+augurs-forecaster = { version = "0.5.1", path = "crates/augurs-forecaster" }
+augurs-mstl = { version = "0.5.1", path = "crates/augurs-mstl" }
+augurs-outlier = { version = "0.5.1", path = "crates/augurs-outlier" }
+augurs-prophet = { version = "0.5.1", path = "crates/augurs-prophet" }
+augurs-seasons = { version = "0.5.1", path = "crates/augurs-seasons" }
 augurs-testing = { path = "crates/augurs-testing" }
 
 anyhow = "1.0.89"

--- a/crates/augurs-changepoint/CHANGELOG.md
+++ b/crates/augurs-changepoint/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.5.0...augurs-changepoint-v0.5.1) - 2024-10-24
+
+### Other
+
+- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
+
 ## [0.5.0](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.5.0...augurs-changepoint-v0.4.3) - 2024-10-18
 
 No changes to the Rust crate; this version bump is due to breaking changes in the

--- a/crates/augurs-clustering/CHANGELOG.md
+++ b/crates/augurs-clustering/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/grafana/augurs/compare/augurs-clustering-v0.5.0...augurs-clustering-v0.5.1) - 2024-10-24
+
+### Other
+
+- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
+
 ## [0.5.0](https://github.com/grafana/augurs/compare/augurs-clustering-v0.5.0...augurs-clustering-v0.4.3) - 2024-10-18
 
 No changes to the Rust crate; this version bump is due to breaking changes in the

--- a/crates/augurs-core/CHANGELOG.md
+++ b/crates/augurs-core/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/grafana/augurs/compare/augurs-core-v0.5.0...augurs-core-v0.5.1) - 2024-10-24
+
+### Other
+
+- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
+
 ## [0.5.0](https://github.com/grafana/augurs/compare/augurs-core-v0.5.0...augurs-core-v0.4.3) - 2024-10-18
 
 No changes to the Rust crate; this version bump is due to breaking changes in the

--- a/crates/augurs-dtw/CHANGELOG.md
+++ b/crates/augurs-dtw/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/grafana/augurs/compare/augurs-dtw-v0.5.0...augurs-dtw-v0.5.1) - 2024-10-24
+
+### Other
+
+- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
+
 ## [0.4.0](https://github.com/grafana/augurs/compare/augurs-dtw-v0.3.1...augurs-dtw-v0.4.0) - 2024-10-16
 
 ### Added

--- a/crates/augurs-ets/CHANGELOG.md
+++ b/crates/augurs-ets/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/grafana/augurs/compare/augurs-ets-v0.5.0...augurs-ets-v0.5.1) - 2024-10-24
+
+### Other
+
+- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
+
 ## [0.5.0](https://github.com/grafana/augurs/compare/augurs-ets-v0.5.0...augurs-ets-v0.4.3) - 2024-10-18
 
 No changes to the Rust crate; this version bump is due to breaking changes in the

--- a/crates/augurs-forecaster/CHANGELOG.md
+++ b/crates/augurs-forecaster/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.5.0...augurs-forecaster-v0.5.1) - 2024-10-24
+
+### Other
+
+- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
+
 ## [0.5.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.5.0...augurs-forecaster-v0.4.3) - 2024-10-18
 
 No changes to the Rust crate; this version bump is due to breaking changes in the

--- a/crates/augurs-mstl/CHANGELOG.md
+++ b/crates/augurs-mstl/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/grafana/augurs/compare/augurs-mstl-v0.5.0...augurs-mstl-v0.5.1) - 2024-10-24
+
+### Other
+
+- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
+
 ## [0.5.0](https://github.com/grafana/augurs/compare/augurs-mstl-v0.5.0...augurs-mstl-v0.4.3) - 2024-10-18
 
 No changes to the Rust crate; this version bump is due to breaking changes in the

--- a/crates/augurs-outlier/CHANGELOG.md
+++ b/crates/augurs-outlier/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/grafana/augurs/compare/augurs-outlier-v0.5.0...augurs-outlier-v0.5.1) - 2024-10-24
+
+### Other
+
+- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
+
 ## [0.5.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.5.0...augurs-outlier-v0.4.3) - 2024-10-18
 
 No changes to the Rust crate; this version bump is due to breaking changes in the

--- a/crates/augurs-prophet/CHANGELOG.md
+++ b/crates/augurs-prophet/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/grafana/augurs/compare/augurs-prophet-v0.5.0...augurs-prophet-v0.5.1) - 2024-10-24
+
+### Fixed
+
+- do matrix multiplication for feature calculation properly
+
+### Other
+
+- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
+
 ## [0.5.0](https://github.com/grafana/augurs/compare/augurs-prophet-v0.5.0...augurs-prophet-v0.4.3) - 2024-10-18
 
 No changes to the Rust crate; this version bump is due to breaking changes in the

--- a/crates/augurs-seasons/CHANGELOG.md
+++ b/crates/augurs-seasons/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/grafana/augurs/compare/augurs-seasons-v0.5.0...augurs-seasons-v0.5.1) - 2024-10-24
+
+### Other
+
+- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
+
 ## [0.5.0](https://github.com/grafana/augurs/compare/augurs-seasons-v0.5.0...augurs-seasons-v0.4.3) - 2024-10-18
 
 No changes to the Rust crate; this version bump is due to breaking changes in the

--- a/crates/augurs/CHANGELOG.md
+++ b/crates/augurs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/grafana/augurs/compare/augurs-v0.5.0...augurs-v0.5.1) - 2024-10-24
+
+### Other
+
+- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
+
 ## [0.5.0](https://github.com/grafana/augurs/compare/augurs-v0.5.0...augurs-v0.4.3) - 2024-10-18
 
 No changes to the Rust crate; this version bump is due to breaking changes in the


### PR DESCRIPTION
## 🤖 New release
* `augurs`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `augurs-changepoint`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `augurs-core`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `augurs-clustering`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `augurs-dtw`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `augurs-ets`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `augurs-mstl`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `augurs-forecaster`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `augurs-outlier`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `augurs-prophet`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `augurs-seasons`: 0.5.0 -> 0.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `augurs`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-v0.5.0...augurs-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-changepoint`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.5.0...augurs-changepoint-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-core`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-core-v0.5.0...augurs-core-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-clustering`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-clustering-v0.5.0...augurs-clustering-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-dtw`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-dtw-v0.5.0...augurs-dtw-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-ets`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-ets-v0.5.0...augurs-ets-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-mstl`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-mstl-v0.5.0...augurs-mstl-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-forecaster`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.5.0...augurs-forecaster-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-outlier`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-outlier-v0.5.0...augurs-outlier-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-prophet`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-prophet-v0.5.0...augurs-prophet-v0.5.1) - 2024-10-24

### Fixed

- do matrix multiplication for feature calculation properly

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-seasons`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-seasons-v0.5.0...augurs-seasons-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated all workspace package dependencies to version `0.5.1`, ensuring consistency across components.
  
- **Bug Fixes**
	- Resolved issues related to lint definitions by moving them to the `Cargo.toml` file for better management.

- **Documentation**
	- Changelogs for all components updated to reflect new version entries and significant changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->