### PR TITLE
ci: upload WASM and download in other workflows

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -5,7 +5,11 @@ permissions:
   contents: write
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - prophet-wasmstan
+    types:
+      - "completed"
     branches:
       - main
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,9 +1,11 @@
 name: Rust
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
+  workflow_run:
+    workflows:
+      - prophet-wasmstan
+    types:
+      - "completed"
 
 env:
   CARGO_TERM_COLOR: always
@@ -26,6 +28,10 @@ jobs:
     name: Tests
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: prophet-wasmstan.wasm
+          path: crates/augurs-prophet/prophet-wasmstan.wasm
       - name: Checkout sources
         uses: actions/checkout@v4
 

--- a/.github/workflows/wasmstan.yml
+++ b/.github/workflows/wasmstan.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always
@@ -30,3 +29,7 @@ jobs:
     - uses: actions/setup-node@v4
     - name: Run node test
       run: just components/test
+    - uses: actions/upload-artifact@v4
+      with:
+        name: prophet-wasmstan.wasm
+        path: components/cpp/prophet-wasmstan.wasm


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated workflow configurations to trigger jobs based on the completion of the `prophet-wasmstan` workflow.
	- Added functionality to download and upload artifacts for improved workflow efficiency.
  
- **Bug Fixes**
	- Removed outdated triggers for `push` and `pull_request` events in Rust workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->