### PR TITLE
chore: release v0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ authors = [
 ]
 documentation = "https://docs.rs/crate/augurs"
 repository = "https://github.com/grafana/augurs"
-version = "0.5.4"
+version = "0.6.0"
 edition = "2021"
 keywords = [
   "analysis",
@@ -29,16 +29,16 @@ keywords = [
 
 [workspace.dependencies]
 augurs = { path = "crates/augurs" }
-augurs-changepoint = { version = "0.5.3", path = "crates/augurs-changepoint" }
-augurs-clustering = { version = "0.5.3", path = "crates/augurs-clustering" }
-augurs-core = { version = "0.5.3", path = "crates/augurs-core" }
-augurs-dtw = { version = "0.5.3", path = "crates/augurs-dtw" }
-augurs-ets = { version = "0.5.3", path = "crates/augurs-ets" }
-augurs-forecaster = { version = "0.5.3", path = "crates/augurs-forecaster" }
-augurs-mstl = { version = "0.5.3", path = "crates/augurs-mstl" }
-augurs-outlier = { version = "0.5.3", path = "crates/augurs-outlier" }
-augurs-prophet = { version = "0.5.3", path = "crates/augurs-prophet" }
-augurs-seasons = { version = "0.5.3", path = "crates/augurs-seasons" }
+augurs-changepoint = { version = "0.6.0", path = "crates/augurs-changepoint" }
+augurs-clustering = { version = "0.6.0", path = "crates/augurs-clustering" }
+augurs-core = { version = "0.6.0", path = "crates/augurs-core" }
+augurs-dtw = { version = "0.6.0", path = "crates/augurs-dtw" }
+augurs-ets = { version = "0.6.0", path = "crates/augurs-ets" }
+augurs-forecaster = { version = "0.6.0", path = "crates/augurs-forecaster" }
+augurs-mstl = { version = "0.6.0", path = "crates/augurs-mstl" }
+augurs-outlier = { version = "0.6.0", path = "crates/augurs-outlier" }
+augurs-prophet = { version = "0.6.0", path = "crates/augurs-prophet" }
+augurs-seasons = { version = "0.6.0", path = "crates/augurs-seasons" }
 augurs-testing = { path = "crates/augurs-testing" }
 
 augurs-core-js = { path = "js/augurs-core-js" }

--- a/crates/augurs-dtw/CHANGELOG.md
+++ b/crates/augurs-dtw/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/grafana/augurs/compare/augurs-dtw-v0.5.4...augurs-dtw-v0.6.0) - 2024-11-08
+
+### Added
+
+- [**breaking**] split JS package into separate crates ([#149](https://github.com/grafana/augurs/pull/149))
+
 ## [0.5.2](https://github.com/grafana/augurs/compare/augurs-dtw-v0.5.1...augurs-dtw-v0.5.2) - 2024-10-25
 
 ### Other

--- a/crates/augurs-prophet/CHANGELOG.md
+++ b/crates/augurs-prophet/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/grafana/augurs/compare/augurs-prophet-v0.5.4...augurs-prophet-v0.6.0) - 2024-11-08
+
+### Added
+
+- add wasmtime based optimizer for dependency-free Rust impl
+
+### Other
+
+- Improve error handling in wasmstan optimizer
+
 ## [0.5.3](https://github.com/grafana/augurs/compare/augurs-prophet-v0.5.2...augurs-prophet-v0.5.3) - 2024-10-25
 
 ### Fixed

--- a/crates/augurs/CHANGELOG.md
+++ b/crates/augurs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/grafana/augurs/compare/augurs-v0.5.4...augurs-v0.6.0) - 2024-11-08
+
+### Added
+
+- add wasmtime based optimizer for dependency-free Rust impl
+
 ## [0.5.2](https://github.com/grafana/augurs/compare/augurs-v0.5.1...augurs-v0.5.2) - 2024-10-25
 
 ### Other


### PR DESCRIPTION
## 🤖 New release
* `augurs`: 0.5.4 -> 0.6.0 (✓ API compatible changes)
* `augurs-changepoint`: 0.5.4 -> 0.6.0
* `augurs-core`: 0.5.4 -> 0.6.0
* `augurs-clustering`: 0.5.4 -> 0.6.0
* `augurs-dtw`: 0.5.4 -> 0.6.0 (✓ API compatible changes)
* `augurs-ets`: 0.5.4 -> 0.6.0
* `augurs-mstl`: 0.5.4 -> 0.6.0
* `augurs-forecaster`: 0.5.4 -> 0.6.0
* `augurs-outlier`: 0.5.4 -> 0.6.0
* `augurs-prophet`: 0.5.4 -> 0.6.0 (✓ API compatible changes)
* `augurs-seasons`: 0.5.4 -> 0.6.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `augurs`
<blockquote>

## [0.6.0](https://github.com/grafana/augurs/compare/augurs-v0.5.4...augurs-v0.6.0) - 2024-11-08

### Added

- add wasmtime based optimizer for dependency-free Rust impl
</blockquote>

## `augurs-changepoint`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.5.0...augurs-changepoint-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-core`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-core-v0.5.0...augurs-core-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-clustering`
<blockquote>

## [0.5.2](https://github.com/grafana/augurs/compare/augurs-clustering-v0.5.1...augurs-clustering-v0.5.2) - 2024-10-25

### Other

- add benchmark for Prophet ([#140](https://github.com/grafana/augurs/pull/140))
</blockquote>

## `augurs-dtw`
<blockquote>

## [0.6.0](https://github.com/grafana/augurs/compare/augurs-dtw-v0.5.4...augurs-dtw-v0.6.0) - 2024-11-08

### Added

- [**breaking**] split JS package into separate crates ([#149](https://github.com/grafana/augurs/pull/149))
</blockquote>

## `augurs-ets`
<blockquote>

## [0.5.2](https://github.com/grafana/augurs/compare/augurs-ets-v0.5.1...augurs-ets-v0.5.2) - 2024-10-25

### Other

- add benchmark for Prophet ([#140](https://github.com/grafana/augurs/pull/140))
</blockquote>

## `augurs-mstl`
<blockquote>

## [0.5.2](https://github.com/grafana/augurs/compare/augurs-mstl-v0.5.1...augurs-mstl-v0.5.2) - 2024-10-25

### Other

- add benchmark for Prophet ([#140](https://github.com/grafana/augurs/pull/140))
</blockquote>

## `augurs-forecaster`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.5.0...augurs-forecaster-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-outlier`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-outlier-v0.5.0...augurs-outlier-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-prophet`
<blockquote>

## [0.6.0](https://github.com/grafana/augurs/compare/augurs-prophet-v0.5.4...augurs-prophet-v0.6.0) - 2024-11-08

### Added

- add wasmtime based optimizer for dependency-free Rust impl

### Other

- Improve error handling in wasmstan optimizer
</blockquote>

## `augurs-seasons`
<blockquote>

## [0.5.2](https://github.com/grafana/augurs/compare/augurs-seasons-v0.5.1...augurs-seasons-v0.5.2) - 2024-10-25

### Other

- add benchmark for Prophet ([#140](https://github.com/grafana/augurs/pull/140))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a Wasmtime-based optimizer for a dependency-free Rust implementation.
- **Enhancements**
	- Improved error handling within the wasmstan optimizer.
- **Breaking Changes**
	- JavaScript package has been split into separate crates.
- **Changelog Updates**
	- Version entries for `0.6.0` added across multiple projects, documenting new features and improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->