### PR TITLE
fix: fix build script to work in docs.rs builds

### DIFF
--- a/crates/augurs-prophet/build.rs
+++ b/crates/augurs-prophet/build.rs
@@ -126,8 +126,18 @@ fn copy_wasmstan() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn handle_wasmstan() -> Result<(), Box<dyn std::error::Error>> {
+    let _result = Ok::<(), Box<dyn std::error::Error>>(());
     #[cfg(feature = "wasmstan")]
-    copy_wasmstan()?;
+    let _result = copy_wasmstan();
+
+    if std::env::var("DOCS_RS").is_ok() {
+        // In docs.rs we won't have (or need) the wasmstan file in the current directory,
+        // so we should just create an empty one so the build doesn't fail.
+        create_empty_files(&["prophet-wasmstan.wasm"])?;
+    } else {
+        // Otherwise, fail the build if there was an error.
+        _result?;
+    }
     Ok(())
 }
 


### PR DESCRIPTION
The prophet-wasmstan.wasm file won't exist there so just create an empty file similar to what we do for cmdstan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for the build process based on the `DOCS_RS` environment variable, preventing unnecessary build failures.
  
- **Refactor**
	- Enhanced the error handling logic for better consistency and clarity in the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->