### PR TITLE
Add Prophet WASM example

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,7 +20,7 @@ jobs:
         uses: moonrepo/setup-rust@v1
 
       - name: Run cargo check
-        run: cargo check --all-targets
+        run: cargo check --all-targets --all-features
 
   wasmstan:
     name: Prophet WASMStan component
@@ -83,4 +83,4 @@ jobs:
           components: clippy
 
       - name: Run cargo clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --all-features --all-targets -- -D warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
 
 env:
@@ -39,15 +39,17 @@ jobs:
         with:
           bins: cargo-nextest,just
 
+      # Download the Prophet Stan model since an example requires it.
       - name: Download Prophet Stan model
-        # Download the Prophet Stan model since an example requires it.
         run: just download-prophet-stan-model
 
+      # Download the Prophet wasmstan module since an example and some doctests require it.
       - name: Download Prophet WASMStan component artifact
         uses: actions/download-artifact@v4
         with:
           name: prophet-wasmstan.wasm
           path: crates/augurs-prophet
+
       - name: Run cargo nextest
         run: just test-all
       - name: Run doc tests

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,16 +39,16 @@ jobs:
         with:
           bins: cargo-nextest,just
 
-      # Download the Prophet Stan model since an example requires it.
-      - name: Download Prophet Stan model
-        run: just download-prophet-stan-model
-
       # Download the Prophet wasmstan module since an example and some doctests require it.
       - name: Download Prophet WASMStan component artifact
         uses: actions/download-artifact@v4
         with:
           name: prophet-wasmstan.wasm
           path: crates/augurs-prophet
+
+      # Download the Prophet Stan model since an example requires it.
+      - name: Download Prophet Stan model
+        run: just download-prophet-stan-model
 
       - name: Run cargo nextest
         run: just test-all

--- a/crates/augurs-prophet/Cargo.toml
+++ b/crates/augurs-prophet/Cargo.toml
@@ -45,14 +45,15 @@ bytemuck = ["dep:bytemuck"]
 cmdstan = ["dep:tempfile", "dep:serde_json", "serde"]
 compile-cmdstan = ["cmdstan", "dep:tempfile"]
 download = ["dep:ureq", "dep:zip"]
-# Ignore cmdstan compilation in the build script.
-# This should only be used for developing the library, not by
-# end users, or you may end up with a broken build where the
-# Prophet model isn't available to be compiled into the binary.
-internal-ignore-cmdstan-failure = []
 serde = ["dep:serde"]
 wasmstan = ["wasmstan-min"]
 wasmstan-min = ["dep:serde_json", "dep:wasmtime", "dep:wasmtime-wasi", "serde"]
+
+# Ignore cmdstan compilation or wasmstan copying in the build script.
+# This should only be used for developing the library, not by
+# end users, or you may end up with a broken build where the
+# Prophet model isn't available to be compiled into the binary.
+internal-ignore-build-failures = []
 
 [lib]
 bench = false

--- a/crates/augurs-prophet/Cargo.toml
+++ b/crates/augurs-prophet/Cargo.toml
@@ -8,6 +8,23 @@ version.workspace = true
 edition.workspace = true
 keywords.workspace = true
 description = "Prophet: time-series forecasting at scale, in Rust."
+include = [
+    ".gitignore",
+    "Cargo.toml",
+    "README.md",
+    "LICENSE-APACHE",
+    "LICENSE-MIT",
+    "CHANGELOG.md",
+    "build.rs",
+    "data",
+    "src/**/*",
+    "examples",
+    "tests",
+    "benches",
+    "prophet-wasmstan.wit",
+    "prophet-wasmstan.wasm",
+    "prophet.stan",
+]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/augurs-prophet/build.rs
+++ b/crates/augurs-prophet/build.rs
@@ -49,13 +49,29 @@ fn compile_cmdstan_model() -> Result<(), Box<dyn std::error::Error>> {
 
     // Copy the executable to the final location.
     let dest_exe_path = build_dir.join("prophet");
-    std::fs::copy(tmp_exe_path, &dest_exe_path)?;
+    std::fs::copy(&tmp_exe_path, &dest_exe_path).map_err(|e| {
+        eprintln!(
+            "error copying prophet binary from {} to {}: {}",
+            tmp_exe_path.display(),
+            dest_exe_path.display(),
+            e
+        );
+        e
+    })?;
     eprintln!("Copied prophet exe to {}", dest_exe_path.display());
 
     // Copy libtbb to the final location.
     let libtbb_path = stan_path.join("lib/libtbb.so.12");
     let dest_libtbb_path = build_dir.join("libtbb.so.12");
-    std::fs::copy(&libtbb_path, &dest_libtbb_path)?;
+    std::fs::copy(&libtbb_path, &dest_libtbb_path).map_err(|e| {
+        eprintln!(
+            "error copying libtbb from {} to {}: {}",
+            libtbb_path.display(),
+            dest_libtbb_path.display(),
+            e
+        );
+        e
+    })?;
     eprintln!(
         "Copied libtbb.so from {} to {}",
         libtbb_path.display(),
@@ -109,6 +125,8 @@ fn handle_cmdstan() -> Result<(), Box<dyn std::error::Error>> {
 
 #[cfg(feature = "wasmstan")]
 fn copy_wasmstan() -> Result<(), Box<dyn std::error::Error>> {
+    println!("cargo::rerun-if-changed=prophet-wasmstan.wasm");
+
     let out_dir = std::path::PathBuf::from(std::env::var("OUT_DIR")?);
     let prophet_path = std::path::PathBuf::from(concat!(
         env!("CARGO_MANIFEST_DIR"),
@@ -116,7 +134,15 @@ fn copy_wasmstan() -> Result<(), Box<dyn std::error::Error>> {
     ))
     .canonicalize()?;
     let wasmstan_path = out_dir.join("prophet-wasmstan.wasm");
-    std::fs::copy(&prophet_path, &wasmstan_path)?;
+    std::fs::copy(&prophet_path, &wasmstan_path).map_err(|e| {
+        eprintln!(
+            "error copying prophet-wasmstan from {} to {}: {}",
+            prophet_path.display(),
+            wasmstan_path.display(),
+            e
+        );
+        e
+    })?;
     eprintln!(
         "Copied prophet-wasmstan.wasm from {} to {}",
         prophet_path.display(),

--- a/examples/forecasting/Cargo.toml
+++ b/examples/forecasting/Cargo.toml
@@ -11,6 +11,14 @@ keywords.workspace = true
 publish = false
 
 [dependencies]
-augurs = { workspace = true, features = ["ets", "mstl", "forecaster", "prophet", "prophet-cmdstan", "seasons"] }
+augurs = { workspace = true, features = [
+    "ets",
+    "mstl",
+    "forecaster",
+    "prophet",
+    "prophet-cmdstan",
+    "prophet-wasmstan",
+    "seasons",
+] }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, default-features = true }

--- a/examples/forecasting/examples/prophet_wasmstan.rs
+++ b/examples/forecasting/examples/prophet_wasmstan.rs
@@ -1,0 +1,61 @@
+//! Example of using the Prophet model with the cmdstan optimizer.
+//!
+//! To run this example, you must first download the Prophet Stan model
+//! and libtbb shared library into the `prophet_stan_model` directory.
+//! The easiest way to do this is to run the `download-stan-model`
+//! binary in the `augurs-prophet` crate:
+//!
+//! ```sh
+//! $ cargo run --features download --bin download-stan-model
+//! $ cargo run --example prophet_cmdstan
+//! ```
+use std::{collections::HashMap, time::Duration};
+
+use augurs::prophet::{cmdstan::CmdstanOptimizer, Prophet, Regressor, TrainingData};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::fmt::init();
+    tracing::info!("Running Prophet example");
+
+    let ds = vec![
+        1704067200, 1704871384, 1705675569, 1706479753, 1707283938, 1708088123, 1708892307,
+        1709696492, 1710500676, 1711304861, 1712109046, 1712913230, 1713717415,
+    ];
+    let y = vec![
+        1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0,
+    ];
+    let data = TrainingData::new(ds, y.clone())?
+        .with_regressors(HashMap::from([
+            (
+                "foo".to_string(),
+                vec![
+                    1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0, 1.0,
+                ],
+            ),
+            (
+                "bar".to_string(),
+                vec![
+                    4.0, 5.0, 6.0, 4.0, 5.0, 6.0, 4.0, 5.0, 6.0, 4.0, 5.0, 6.0, 4.0,
+                ],
+            ),
+        ]))
+        .unwrap();
+
+    let cmdstan = CmdstanOptimizer::with_prophet_path("prophet_stan_model/prophet_model.bin")?
+        .with_poll_interval(Duration::from_millis(100))
+        .with_refresh(50);
+    // If you were using the embedded version of the cmdstan model, you'd use this:
+    // let cmdstan = CmdstanOptimizer::new_embedded();
+
+    let mut prophet = Prophet::new(Default::default(), cmdstan);
+    prophet.add_regressor("foo".to_string(), Regressor::additive());
+    prophet.add_regressor("bar".to_string(), Regressor::additive());
+
+    prophet.fit(data, Default::default())?;
+    let predictions = prophet.predict(None)?;
+    assert_eq!(predictions.yhat.point.len(), y.len());
+    assert!(predictions.yhat.lower.is_some());
+    assert!(predictions.yhat.upper.is_some());
+    println!("Predicted values: {:#?}", predictions.yhat);
+    Ok(())
+}


### PR DESCRIPTION
Adds an example of using Prophet with the wasmstan optimizer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new example for using the Prophet model with the CmdStan optimizer.
	- Enhanced the `augurs` dependency to include the `prophet-wasmstan` feature.

- **Bug Fixes**
	- Improved error handling in the build script for CmdStan and WASM functionalities.

- **Documentation**
	- Updated comments and documentation for clarity regarding new and existing features.

- **Chores**
	- Minor formatting adjustments in workflow configurations and dependencies for better readability.
	- Added an `include` section in the `Cargo.toml` for comprehensive file inclusion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->