### PR TITLE
chore: release v0.6.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ authors = [
 ]
 documentation = "https://docs.rs/crate/augurs"
 repository = "https://github.com/grafana/augurs"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 keywords = [
   "analysis",
@@ -29,16 +29,16 @@ keywords = [
 
 [workspace.dependencies]
 augurs = { path = "crates/augurs" }
-augurs-changepoint = { version = "0.6.1", path = "crates/augurs-changepoint" }
-augurs-clustering = { version = "0.6.1", path = "crates/augurs-clustering" }
-augurs-core = { version = "0.6.1", path = "crates/augurs-core" }
-augurs-dtw = { version = "0.6.1", path = "crates/augurs-dtw" }
-augurs-ets = { version = "0.6.1", path = "crates/augurs-ets" }
-augurs-forecaster = { version = "0.6.1", path = "crates/augurs-forecaster" }
-augurs-mstl = { version = "0.6.1", path = "crates/augurs-mstl" }
-augurs-outlier = { version = "0.6.1", path = "crates/augurs-outlier" }
-augurs-prophet = { version = "0.6.1", path = "crates/augurs-prophet" }
-augurs-seasons = { version = "0.6.1", path = "crates/augurs-seasons" }
+augurs-changepoint = { version = "0.6.2", path = "crates/augurs-changepoint" }
+augurs-clustering = { version = "0.6.2", path = "crates/augurs-clustering" }
+augurs-core = { version = "0.6.2", path = "crates/augurs-core" }
+augurs-dtw = { version = "0.6.2", path = "crates/augurs-dtw" }
+augurs-ets = { version = "0.6.2", path = "crates/augurs-ets" }
+augurs-forecaster = { version = "0.6.2", path = "crates/augurs-forecaster" }
+augurs-mstl = { version = "0.6.2", path = "crates/augurs-mstl" }
+augurs-outlier = { version = "0.6.2", path = "crates/augurs-outlier" }
+augurs-prophet = { version = "0.6.2", path = "crates/augurs-prophet" }
+augurs-seasons = { version = "0.6.2", path = "crates/augurs-seasons" }
 augurs-testing = { path = "crates/augurs-testing" }
 
 augurs-core-js = { path = "js/augurs-core-js" }

--- a/crates/augurs-prophet/CHANGELOG.md
+++ b/crates/augurs-prophet/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/grafana/augurs/compare/augurs-prophet-v0.6.1...augurs-prophet-v0.6.2) - 2024-11-10
+
+### Fixed
+
+- use OUT_DIR instead of CARGO_MANIFEST_DIR
+
+### Other
+
+- Add Prophet WASM example ([#152](https://github.com/grafana/augurs/pull/152))
+
 ## [0.6.1](https://github.com/grafana/augurs/compare/augurs-prophet-v0.6.0...augurs-prophet-v0.6.1) - 2024-11-09
 
 ### Fixed


### PR DESCRIPTION
## 🤖 New release
* `augurs`: 0.6.1 -> 0.6.2
* `augurs-changepoint`: 0.6.1 -> 0.6.2
* `augurs-core`: 0.6.1 -> 0.6.2
* `augurs-clustering`: 0.6.1 -> 0.6.2
* `augurs-dtw`: 0.6.1 -> 0.6.2
* `augurs-ets`: 0.6.1 -> 0.6.2
* `augurs-mstl`: 0.6.1 -> 0.6.2
* `augurs-forecaster`: 0.6.1 -> 0.6.2
* `augurs-outlier`: 0.6.1 -> 0.6.2
* `augurs-prophet`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `augurs-seasons`: 0.6.1 -> 0.6.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `augurs`
<blockquote>

## [0.6.0](https://github.com/grafana/augurs/compare/augurs-v0.5.4...augurs-v0.6.0) - 2024-11-08

### Added

- add wasmtime based optimizer for dependency-free Rust impl
</blockquote>

## `augurs-changepoint`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.5.0...augurs-changepoint-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-core`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-core-v0.5.0...augurs-core-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-clustering`
<blockquote>

## [0.5.2](https://github.com/grafana/augurs/compare/augurs-clustering-v0.5.1...augurs-clustering-v0.5.2) - 2024-10-25

### Other

- add benchmark for Prophet ([#140](https://github.com/grafana/augurs/pull/140))
</blockquote>

## `augurs-dtw`
<blockquote>

## [0.6.0](https://github.com/grafana/augurs/compare/augurs-dtw-v0.5.4...augurs-dtw-v0.6.0) - 2024-11-08

### Added

- [**breaking**] split JS package into separate crates ([#149](https://github.com/grafana/augurs/pull/149))
</blockquote>

## `augurs-ets`
<blockquote>

## [0.5.2](https://github.com/grafana/augurs/compare/augurs-ets-v0.5.1...augurs-ets-v0.5.2) - 2024-10-25

### Other

- add benchmark for Prophet ([#140](https://github.com/grafana/augurs/pull/140))
</blockquote>

## `augurs-mstl`
<blockquote>

## [0.5.2](https://github.com/grafana/augurs/compare/augurs-mstl-v0.5.1...augurs-mstl-v0.5.2) - 2024-10-25

### Other

- add benchmark for Prophet ([#140](https://github.com/grafana/augurs/pull/140))
</blockquote>

## `augurs-forecaster`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.5.0...augurs-forecaster-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-outlier`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-outlier-v0.5.0...augurs-outlier-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-prophet`
<blockquote>

## [0.6.2](https://github.com/grafana/augurs/compare/augurs-prophet-v0.6.1...augurs-prophet-v0.6.2) - 2024-11-10

### Fixed

- use OUT_DIR instead of CARGO_MANIFEST_DIR

### Other

- Add Prophet WASM example ([#152](https://github.com/grafana/augurs/pull/152))
</blockquote>

## `augurs-seasons`
<blockquote>

## [0.5.2](https://github.com/grafana/augurs/compare/augurs-seasons-v0.5.1...augurs-seasons-v0.5.2) - 2024-10-25

### Other

- add benchmark for Prophet ([#140](https://github.com/grafana/augurs/pull/140))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated workspace package version to `0.6.2`.
	- Introduced a new example for Prophet WASM.
  
- **Bug Fixes**
	- Replaced `CARGO_MANIFEST_DIR` with `OUT_DIR` in the Prophet package.
  
- **Documentation**
	- Updated changelog to reflect changes and enhancements in version `0.6.2`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->