### PR TITLE
chore: release v0.6.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ authors = [
 ]
 documentation = "https://docs.rs/crate/augurs"
 repository = "https://github.com/grafana/augurs"
-version = "0.6.2"
+version = "0.6.3"
 edition = "2021"
 keywords = [
   "analysis",
@@ -29,16 +29,16 @@ keywords = [
 
 [workspace.dependencies]
 augurs = { path = "crates/augurs" }
-augurs-changepoint = { version = "0.6.2", path = "crates/augurs-changepoint" }
-augurs-clustering = { version = "0.6.2", path = "crates/augurs-clustering" }
-augurs-core = { version = "0.6.2", path = "crates/augurs-core" }
-augurs-dtw = { version = "0.6.2", path = "crates/augurs-dtw" }
-augurs-ets = { version = "0.6.2", path = "crates/augurs-ets" }
-augurs-forecaster = { version = "0.6.2", path = "crates/augurs-forecaster" }
-augurs-mstl = { version = "0.6.2", path = "crates/augurs-mstl" }
-augurs-outlier = { version = "0.6.2", path = "crates/augurs-outlier" }
-augurs-prophet = { version = "0.6.2", path = "crates/augurs-prophet" }
-augurs-seasons = { version = "0.6.2", path = "crates/augurs-seasons" }
+augurs-changepoint = { version = "0.6.3", path = "crates/augurs-changepoint" }
+augurs-clustering = { version = "0.6.3", path = "crates/augurs-clustering" }
+augurs-core = { version = "0.6.3", path = "crates/augurs-core" }
+augurs-dtw = { version = "0.6.3", path = "crates/augurs-dtw" }
+augurs-ets = { version = "0.6.3", path = "crates/augurs-ets" }
+augurs-forecaster = { version = "0.6.3", path = "crates/augurs-forecaster" }
+augurs-mstl = { version = "0.6.3", path = "crates/augurs-mstl" }
+augurs-outlier = { version = "0.6.3", path = "crates/augurs-outlier" }
+augurs-prophet = { version = "0.6.3", path = "crates/augurs-prophet" }
+augurs-seasons = { version = "0.6.3", path = "crates/augurs-seasons" }
 augurs-testing = { path = "crates/augurs-testing" }
 
 augurs-core-js = { path = "js/augurs-core-js" }

--- a/crates/augurs-changepoint/CHANGELOG.md
+++ b/crates/augurs-changepoint/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.6.2...augurs-changepoint-v0.6.3) - 2024-11-20
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.5.1](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.5.0...augurs-changepoint-v0.5.1) - 2024-10-24
 
 ### Other

--- a/crates/augurs-ets/CHANGELOG.md
+++ b/crates/augurs-ets/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3](https://github.com/grafana/augurs/compare/augurs-ets-v0.6.2...augurs-ets-v0.6.3) - 2024-11-20
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.5.2](https://github.com/grafana/augurs/compare/augurs-ets-v0.5.1...augurs-ets-v0.5.2) - 2024-10-25
 
 ### Other

--- a/crates/augurs-mstl/CHANGELOG.md
+++ b/crates/augurs-mstl/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3](https://github.com/grafana/augurs/compare/augurs-mstl-v0.6.2...augurs-mstl-v0.6.3) - 2024-11-20
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.5.2](https://github.com/grafana/augurs/compare/augurs-mstl-v0.5.1...augurs-mstl-v0.5.2) - 2024-10-25
 
 ### Other

--- a/crates/augurs-prophet/CHANGELOG.md
+++ b/crates/augurs-prophet/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3](https://github.com/grafana/augurs/compare/augurs-prophet-v0.6.2...augurs-prophet-v0.6.3) - 2024-11-20
+
+### Fixed
+
+- correctly set holiday feature to 1 for all holiday dates ([#175](https://github.com/grafana/augurs/pull/175))
+
+### Other
+
+- Fix broken intra-doc link in wasmstan module
+
 ## [0.6.2](https://github.com/grafana/augurs/compare/augurs-prophet-v0.6.1...augurs-prophet-v0.6.2) - 2024-11-10
 
 ### Fixed

--- a/crates/augurs-seasons/CHANGELOG.md
+++ b/crates/augurs-seasons/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.3](https://github.com/grafana/augurs/compare/augurs-seasons-v0.6.2...augurs-seasons-v0.6.3) - 2024-11-20
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.5.2](https://github.com/grafana/augurs/compare/augurs-seasons-v0.5.1...augurs-seasons-v0.5.2) - 2024-10-25
 
 ### Other


### PR DESCRIPTION
## 🤖 New release
* `augurs`: 0.6.2 -> 0.6.3
* `augurs-changepoint`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `augurs-core`: 0.6.2 -> 0.6.3
* `augurs-clustering`: 0.6.2 -> 0.6.3
* `augurs-dtw`: 0.6.2 -> 0.6.3
* `augurs-ets`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `augurs-mstl`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `augurs-forecaster`: 0.6.2 -> 0.6.3
* `augurs-outlier`: 0.6.2 -> 0.6.3
* `augurs-prophet`: 0.6.2 -> 0.6.3 (✓ API compatible changes)
* `augurs-seasons`: 0.6.2 -> 0.6.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `augurs`
<blockquote>

## [0.6.0](https://github.com/grafana/augurs/compare/augurs-v0.5.4...augurs-v0.6.0) - 2024-11-08

### Added

- add wasmtime based optimizer for dependency-free Rust impl
</blockquote>

## `augurs-changepoint`
<blockquote>

## [0.6.3](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.6.2...augurs-changepoint-v0.6.3) - 2024-11-20

### Other

- update Cargo.toml dependencies
</blockquote>

## `augurs-core`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-core-v0.5.0...augurs-core-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-clustering`
<blockquote>

## [0.5.2](https://github.com/grafana/augurs/compare/augurs-clustering-v0.5.1...augurs-clustering-v0.5.2) - 2024-10-25

### Other

- add benchmark for Prophet ([#140](https://github.com/grafana/augurs/pull/140))
</blockquote>

## `augurs-dtw`
<blockquote>

## [0.6.0](https://github.com/grafana/augurs/compare/augurs-dtw-v0.5.4...augurs-dtw-v0.6.0) - 2024-11-08

### Added

- [**breaking**] split JS package into separate crates ([#149](https://github.com/grafana/augurs/pull/149))
</blockquote>

## `augurs-ets`
<blockquote>

## [0.6.3](https://github.com/grafana/augurs/compare/augurs-ets-v0.6.2...augurs-ets-v0.6.3) - 2024-11-20

### Other

- update Cargo.toml dependencies
</blockquote>

## `augurs-mstl`
<blockquote>

## [0.6.3](https://github.com/grafana/augurs/compare/augurs-mstl-v0.6.2...augurs-mstl-v0.6.3) - 2024-11-20

### Other

- update Cargo.toml dependencies
</blockquote>

## `augurs-forecaster`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.5.0...augurs-forecaster-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-outlier`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-outlier-v0.5.0...augurs-outlier-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-prophet`
<blockquote>

## [0.6.3](https://github.com/grafana/augurs/compare/augurs-prophet-v0.6.2...augurs-prophet-v0.6.3) - 2024-11-20

### Fixed

- correctly set holiday feature to 1 for all holiday dates ([#175](https://github.com/grafana/augurs/pull/175))

### Other

- Fix broken intra-doc link in wasmstan module
</blockquote>

## `augurs-seasons`
<blockquote>

## [0.6.3](https://github.com/grafana/augurs/compare/augurs-seasons-v0.6.2...augurs-seasons-v0.6.3) - 2024-11-20

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the workspace package and all dependencies to version 0.6.3, ensuring compatibility and alignment across components.
	- Introduced a fix for the holiday feature in the augurs-prophet project.

- **Bug Fixes**
	- Resolved a broken intra-doc link in the augurs-prophet module.

- **Documentation**
	- Added new version entries in changelogs for multiple projects, detailing updates and enhancements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->