### PR TITLE
ci: add attestations for Python releases

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -158,8 +158,19 @@ jobs:
     runs-on: ubuntu-22.04
     if: "startsWith(github.ref, 'refs/tags/pyaugurs-')"
     needs: [linux, musllinux, windows, macos, sdist]
+    permissions:
+      # Use to sign the release artifacts
+      id-token: write
+      # Used to upload release artifacts
+      contents: write
+      # Used to generate artifact attestation
+      attestations: write
     steps:
       - uses: actions/download-artifact@v4
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: 'wheels-*/*'
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         env:


### PR DESCRIPTION
Added by maturin's generate workflow command.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new `release` job in the workflow for improved artifact management.
	- Added artifact attestation generation for enhanced release integrity.
- **Permissions**
	- Updated permissions for the `release` job to allow writing for `id-token`, `contents`, and `attestations`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->