### PR TITLE
fix: correctly set holiday feature to 1 for all holiday dates

### DIFF
--- a/crates/augurs-prophet/src/prophet/prep.rs
+++ b/crates/augurs-prophet/src/prophet/prep.rs
@@ -687,11 +687,11 @@ impl<O> Prophet<O> {
                     };
                     let mut col = vec![0.0; ds.len()];
 
-                    // Get the index of the adjusted date in the original data, if it exists.
-                    // Set the value of the holiday column 1.0 for that date.
-                    if let Some(loc) = ds
+                    // Get the indices of the ds column that are 'on holiday'.
+                    // Set the value of the holiday column 1.0 for those dates.
+                    for loc in ds
                         .iter()
-                        .position(|x| (x - (x % ONE_DAY_IN_SECONDS_INT)) == occurrence)
+                        .positions(|x| (x - (x % ONE_DAY_IN_SECONDS_INT)) == occurrence)
                     {
                         col[loc] = 1.0;
                     }


### PR DESCRIPTION
Prior to this commit, the holiday feature was only set to 1 for the
first occurrence of a holiday date. This meant that the holiday
effect was only applied to predictions for that single datetime
in the dataframe, rather than all dates in the dataframe that
were on the holidays.

This commit fixes that by iterating over all dates in the dataframe
that are on the holiday, and setting the holiday feature to 1.0 for
those dates.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced holiday feature generation by identifying multiple occurrences of holidays in the dataset, allowing for more accurate modeling.
	- Updated logic ensures all relevant holiday dates are marked correctly in the feature matrix.

- **Documentation**
	- Minor adjustments made to comments for clarity on the new holiday occurrence handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->