### PR TITLE
fix: support holidays on non-UTC time zones

### DIFF
--- a/crates/augurs-prophet/src/features.rs
+++ b/crates/augurs-prophet/src/features.rs
@@ -83,8 +83,12 @@ impl Holiday {
 
     /// Set the UTC offset for the holiday, in seconds.
     ///
-    /// The UTC offset is used when deciding whether a timestamp is
-    /// on the holiday.
+    /// Timestamps of a holiday's occurrences are rounded down to the nearest day,
+    /// but since we're using Unix timestamps rather than timezone-aware dates,
+    /// holidays default to assuming the 'day' was for 24h from midnight UTC.
+    ///
+    /// If instead the holiday should be from midnight in a different timezone,
+    /// use this method to set the offset from UTC of the desired timezone.
     ///
     /// Defaults to 0.
     pub fn with_utc_offset(mut self, utc_offset: TimestampSeconds) -> Self {

--- a/crates/augurs-prophet/src/prophet/prep.rs
+++ b/crates/augurs-prophet/src/prophet/prep.rs
@@ -16,7 +16,7 @@ use crate::{
 const ONE_YEAR_IN_SECONDS: f64 = 365.25 * 24.0 * 60.0 * 60.0;
 const ONE_WEEK_IN_SECONDS: f64 = 7.0 * 24.0 * 60.0 * 60.0;
 const ONE_DAY_IN_SECONDS: f64 = 24.0 * 60.0 * 60.0;
-const ONE_DAY_IN_SECONDS_INT: i64 = 24 * 60 * 60;
+pub(crate) const ONE_DAY_IN_SECONDS_INT: i64 = 24 * 60 * 60;
 
 #[derive(Debug, Clone, Default)]
 pub(super) struct Scales {
@@ -682,10 +682,9 @@ impl<O> Prophet<O> {
                 })
                 .unwrap_or_else(|| Box::new(std::iter::repeat(0)));
 
-            for (dt, lower, upper) in izip!(holiday.ds, lower, upper) {
+            for (dt, lower, upper) in izip!(&holiday.ds, lower, upper) {
                 // Round down the original timestamps to the nearest day.
-                let remainder = dt % ONE_DAY_IN_SECONDS_INT;
-                let dt_date = dt - remainder;
+                let dt_date = holiday.floor_day(*dt);
 
                 // Check each of the possible offsets allowed by the lower/upper windows.
                 // We know that the lower window is always positive since it was originally
@@ -702,11 +701,8 @@ impl<O> Prophet<O> {
                         .or_insert_with(|| vec![0.0; ds.len()]);
 
                     // Get the indices of the ds column that are 'on holiday'.
-                    // Set the value of the holiday column 1.0 for those dates.
-                    for loc in ds
-                        .iter()
-                        .positions(|x| (x - (x % ONE_DAY_IN_SECONDS_INT)) == occurrence)
-                    {
+                    // Set the value of the holiday column to 1.0 for those dates.
+                    for loc in ds.iter().positions(|&x| holiday.floor_day(x) == occurrence) {
                         col[loc] = 1.0;
                     }
                 }
@@ -1094,8 +1090,18 @@ mod test {
 
     use super::*;
     use augurs_testing::assert_approx_eq;
-    use chrono::NaiveDate;
+    use chrono::{FixedOffset, NaiveDate, TimeZone, Utc};
     use pretty_assertions::assert_eq;
+
+    macro_rules! concat_all {
+        ($($x:expr),+ $(,)?) => {{
+            let mut result = Vec::new();
+            $(
+                result.extend($x.iter().cloned());
+            )+
+            result
+        }};
+    }
 
     #[test]
     fn setup_dataframe() {
@@ -1210,6 +1216,159 @@ mod test {
                 .copied()
                 .nanmax(true)
                 < 1.0
+        );
+    }
+
+    #[test]
+    fn make_holiday_features() {
+        // Create some hourly data between 2024-01-01 and 2024-01-07.
+        let start = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let end = Utc.with_ymd_and_hms(2024, 1, 7, 0, 0, 0).unwrap();
+        let ds = std::iter::successors(Some(start), |d| {
+            d.checked_add_signed(chrono::Duration::hours(1))
+        })
+        .take_while(|d| *d < end)
+        .map(|d| d.timestamp())
+        .collect_vec();
+        // Create two holidays: one in UTC on 2024-01-02 and 2024-01-04;
+        // one in UTC-3 on the same dates.
+        // The holidays may appear more than once since the data is hourly,
+        // and this shouldn't affect the results.
+        // Ignore windows for now.
+        let non_utc_tz = FixedOffset::west_opt(3600 * 3).unwrap();
+        let holidays: HashMap<String, Holiday> = [
+            (
+                "UTC holiday".to_string(),
+                Holiday::new(vec![
+                    Utc.with_ymd_and_hms(2024, 1, 2, 0, 0, 0)
+                        .unwrap()
+                        .timestamp(),
+                    Utc.with_ymd_and_hms(2024, 1, 2, 12, 0, 0)
+                        .unwrap()
+                        .timestamp(),
+                    Utc.with_ymd_and_hms(2024, 1, 4, 0, 0, 0)
+                        .unwrap()
+                        .timestamp(),
+                ]),
+            ),
+            (
+                "Non-UTC holiday".to_string(),
+                Holiday::new(vec![
+                    non_utc_tz
+                        .with_ymd_and_hms(2024, 1, 2, 0, 0, 0)
+                        .unwrap()
+                        .timestamp(),
+                    non_utc_tz
+                        .with_ymd_and_hms(2024, 1, 2, 12, 0, 0)
+                        .unwrap()
+                        .timestamp(),
+                    non_utc_tz
+                        .with_ymd_and_hms(2024, 1, 4, 0, 0, 0)
+                        .unwrap()
+                        .timestamp(),
+                ])
+                .with_utc_offset(-3 * 3600),
+            ),
+            (
+                "Non-UTC holiday with windows".to_string(),
+                Holiday::new(vec![
+                    non_utc_tz
+                        .with_ymd_and_hms(2024, 1, 2, 0, 0, 0)
+                        .unwrap()
+                        .timestamp(),
+                    non_utc_tz
+                        .with_ymd_and_hms(2024, 1, 2, 12, 0, 0)
+                        .unwrap()
+                        .timestamp(),
+                    non_utc_tz
+                        .with_ymd_and_hms(2024, 1, 4, 0, 0, 0)
+                        .unwrap()
+                        .timestamp(),
+                ])
+                .with_lower_window(vec![1; 3])
+                .unwrap()
+                .with_upper_window(vec![1; 3])
+                .unwrap()
+                .with_utc_offset(-3 * 3600),
+            ),
+        ]
+        .into();
+        let opts = ProphetOptions {
+            holidays: holidays.clone(),
+            ..Default::default()
+        };
+        let prophet = Prophet::new(opts, MockOptimizer::new());
+        let mut features_frame = FeaturesFrame::new();
+        let mut prior_scales = Vec::new();
+        let mut modes = Modes::default();
+
+        let holiday_names = prophet.make_holiday_features(
+            &ds,
+            holidays,
+            &mut features_frame,
+            &mut prior_scales,
+            &mut modes,
+        );
+        assert_eq!(
+            holiday_names,
+            HashSet::from([
+                "UTC holiday".to_string(),
+                "Non-UTC holiday".to_string(),
+                "Non-UTC holiday with windows".to_string()
+            ])
+        );
+
+        assert_eq!(features_frame.names.len(), 5);
+        let utc_idx = features_frame
+            .names
+            .iter()
+            .position(|x| matches!(x, FeatureName::Holiday { name, .. } if name == "UTC holiday"))
+            .unwrap();
+        assert_eq!(
+            features_frame.data[utc_idx],
+            concat_all!(
+                &[0.0; 24], // 2024-01-01 - off holiday
+                &[1.0; 24], // 2024-01-02 - on holiday
+                &[0.0; 24], // 2024-01-03 - off holiday
+                &[1.0; 24], // 2024-01-04 - on holiday
+                &[0.0; 48], // 2024-01-05 and 2024-01-06 - off holiday
+            ),
+        );
+        let non_utc_idx = features_frame
+            .names
+            .iter()
+            .position(
+                |x| matches!(x, FeatureName::Holiday { name, .. } if name == "Non-UTC holiday"),
+            )
+            .unwrap();
+        assert_eq!(
+            features_frame.data[non_utc_idx],
+            concat_all!(
+                &[0.0; 24], // 2024-01-01 - off holiday
+                &[0.0; 3],  // first 3 hours of 2024-01-02 in UTC are off holiday
+                &[1.0; 24], // rest of 2024-01-02 in UTC, and first 3 hours of the next day, are on holiday
+                &[0.0; 24], // continue the cycle...
+                &[1.0; 24],
+                &[0.0; 21 + 24],
+            ),
+        );
+
+        let non_utc_lower_window_idx = features_frame
+            .names
+            .iter()
+            .position(
+                |x| matches!(x, FeatureName::Holiday { name, _offset: -1 } if name == "Non-UTC holiday with windows"),
+            )
+            .unwrap();
+        assert_eq!(
+            features_frame.data[non_utc_lower_window_idx],
+            concat_all!(
+                &[0.0; 3],  // first 3 hours of 2024-01-01 in UTC - off holiday
+                &[1.0; 24], // rest of 2024-01-01 and start of 2024-01-02 are on holiday
+                &[0.0; 24], // continue the cycle
+                &[1.0; 24],
+                &[0.0; 21 + 48],
+            ),
         );
     }
 

--- a/js/augurs-prophet-js/src/lib.rs
+++ b/js/augurs-prophet-js/src/lib.rs
@@ -1247,6 +1247,14 @@ pub struct Holiday {
     /// The prior scale for the holiday.
     #[tsify(optional)]
     pub prior_scale: Option<f64>,
+
+    /// The UTC offset for the holiday, in seconds.
+    ///
+    /// The UTC offset is used when deciding whether a timestamp is
+    /// on the holiday.
+    #[tsify(optional)]
+    #[tsify(type = "TimestampSeconds | undefined")]
+    pub utc_offset_seconds: Option<TimestampSeconds>,
 }
 
 impl TryFrom<Holiday> for augurs_prophet::Holiday {
@@ -1262,6 +1270,9 @@ impl TryFrom<Holiday> for augurs_prophet::Holiday {
         }
         if let Some(prior_scale) = value.prior_scale {
             holiday = holiday.with_prior_scale(prior_scale.try_into()?);
+        }
+        if let Some(utc_offset_seconds) = value.utc_offset_seconds {
+            holiday = holiday.with_utc_offset(utc_offset_seconds);
         }
         Ok(holiday)
     }


### PR DESCRIPTION
Prior to this commit, when determining whether a given holiday's features should be 0 or 1 for a given timestamp, we checked whether each _day_ included in the holiday's lower-upper windows included the timestamp, and set the value to 1 if so. However, when rounding the holiday's timestamps down to 'day' we assumed that the holiday started and ended at midnight UTC, which won't be the case for certain holidays (i.e. anything outside of UTC).

This commit adds the `Holiday::with_utc_offset()` method which allows a holiday to use non-UTC-aligned days when its timestamps are being floored. It also adds tests for the `make_holiday_features` function to ensure the UTC offset is being respected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `Holiday` struct with new `utc_offset` and `utc_offset_seconds` fields for better timestamp handling.
	- Added functionality to accurately create holiday features considering time zone offsets.

- **Bug Fixes**
	- Refined logic for holiday feature generation to ensure accurate timestamp rounding and feature creation.

- **Tests**
	- Expanded test suite with new cases to validate holiday feature generation and timestamp adjustments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->