### PR TITLE
chore: release v0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ authors = [
 ]
 documentation = "https://docs.rs/crate/augurs"
 repository = "https://github.com/grafana/augurs"
-version = "0.6.3"
+version = "0.7.0"
 edition = "2021"
 keywords = [
   "analysis",
@@ -29,16 +29,16 @@ keywords = [
 
 [workspace.dependencies]
 augurs = { path = "crates/augurs" }
-augurs-changepoint = { version = "0.6.3", path = "crates/augurs-changepoint" }
-augurs-clustering = { version = "0.6.3", path = "crates/augurs-clustering" }
-augurs-core = { version = "0.6.3", path = "crates/augurs-core" }
-augurs-dtw = { version = "0.6.3", path = "crates/augurs-dtw" }
-augurs-ets = { version = "0.6.3", path = "crates/augurs-ets" }
-augurs-forecaster = { version = "0.6.3", path = "crates/augurs-forecaster" }
-augurs-mstl = { version = "0.6.3", path = "crates/augurs-mstl" }
-augurs-outlier = { version = "0.6.3", path = "crates/augurs-outlier" }
-augurs-prophet = { version = "0.6.3", path = "crates/augurs-prophet" }
-augurs-seasons = { version = "0.6.3", path = "crates/augurs-seasons" }
+augurs-changepoint = { version = "0.7.0", path = "crates/augurs-changepoint" }
+augurs-clustering = { version = "0.7.0", path = "crates/augurs-clustering" }
+augurs-core = { version = "0.7.0", path = "crates/augurs-core" }
+augurs-dtw = { version = "0.7.0", path = "crates/augurs-dtw" }
+augurs-ets = { version = "0.7.0", path = "crates/augurs-ets" }
+augurs-forecaster = { version = "0.7.0", path = "crates/augurs-forecaster" }
+augurs-mstl = { version = "0.7.0", path = "crates/augurs-mstl" }
+augurs-outlier = { version = "0.7.0", path = "crates/augurs-outlier" }
+augurs-prophet = { version = "0.7.0", path = "crates/augurs-prophet" }
+augurs-seasons = { version = "0.7.0", path = "crates/augurs-seasons" }
 augurs-testing = { path = "crates/augurs-testing" }
 
 augurs-core-js = { path = "js/augurs-core-js" }

--- a/crates/augurs-changepoint/CHANGELOG.md
+++ b/crates/augurs-changepoint/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.6.3...augurs-changepoint-v0.7.0) - 2024-11-25
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.6.3](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.6.2...augurs-changepoint-v0.6.3) - 2024-11-20
 
 ### Other

--- a/crates/augurs-ets/CHANGELOG.md
+++ b/crates/augurs-ets/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/grafana/augurs/compare/augurs-ets-v0.6.3...augurs-ets-v0.7.0) - 2024-11-25
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.6.3](https://github.com/grafana/augurs/compare/augurs-ets-v0.6.2...augurs-ets-v0.6.3) - 2024-11-20
 
 ### Other

--- a/crates/augurs-forecaster/CHANGELOG.md
+++ b/crates/augurs-forecaster/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.6.3...augurs-forecaster-v0.7.0) - 2024-11-25
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.5.1](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.5.0...augurs-forecaster-v0.5.1) - 2024-10-24
 
 ### Other

--- a/crates/augurs-mstl/CHANGELOG.md
+++ b/crates/augurs-mstl/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/grafana/augurs/compare/augurs-mstl-v0.6.3...augurs-mstl-v0.7.0) - 2024-11-25
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.6.3](https://github.com/grafana/augurs/compare/augurs-mstl-v0.6.2...augurs-mstl-v0.6.3) - 2024-11-20
 
 ### Other

--- a/crates/augurs-outlier/CHANGELOG.md
+++ b/crates/augurs-outlier/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.6.3...augurs-outlier-v0.7.0) - 2024-11-25
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.5.1](https://github.com/grafana/augurs/compare/augurs-outlier-v0.5.0...augurs-outlier-v0.5.1) - 2024-10-24
 
 ### Other

--- a/crates/augurs-prophet/CHANGELOG.md
+++ b/crates/augurs-prophet/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/grafana/augurs/compare/augurs-prophet-v0.6.3...augurs-prophet-v0.7.0) - 2024-11-25
+
+### Added
+
+- feat!(prophet): support sub-daily & non-UTC holidays ([#181](https://github.com/grafana/augurs/pull/181))
+
+### Fixed
+
+- add a separate feature for each holiday's lower/upper windows ([#179](https://github.com/grafana/augurs/pull/179))
+
+### Other
+
+- *(deps)* update thiserror requirement from 1.0.40 to 2.0.3 ([#164](https://github.com/grafana/augurs/pull/164))
+- *(deps)* update wasmtime requirement from 26 to 27 ([#183](https://github.com/grafana/augurs/pull/183))
+- use u32 instead of i32 for lower/upper windows ([#177](https://github.com/grafana/augurs/pull/177))
+
 ## [0.6.3](https://github.com/grafana/augurs/compare/augurs-prophet-v0.6.2...augurs-prophet-v0.6.3) - 2024-11-20
 
 ### Fixed

--- a/crates/augurs-prophet/CHANGELOG.md
+++ b/crates/augurs-prophet/CHANGELOG.md
@@ -9,19 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0](https://github.com/grafana/augurs/compare/augurs-prophet-v0.6.3...augurs-prophet-v0.7.0) - 2024-11-25
 
-### Added
+### Breaking Changes
 
-- feat!(prophet): support sub-daily & non-UTC holidays ([#181](https://github.com/grafana/augurs/pull/181))
+- Support sub-daily & non-UTC holidays ([#181](https://github.com/grafana/augurs/pull/181))
+- Changed type of lower/upper windows from `i32` to `u32` ([#177](https://github.com/grafana/augurs/pull/177))
+- *(deps)* update wasmtime requirement from 26 to 27 ([#183](https://github.com/grafana/augurs/pull/183))
 
 ### Fixed
 
 - add a separate feature for each holiday's lower/upper windows ([#179](https://github.com/grafana/augurs/pull/179))
 
-### Other
+### Dependencies
 
 - *(deps)* update thiserror requirement from 1.0.40 to 2.0.3 ([#164](https://github.com/grafana/augurs/pull/164))
 - *(deps)* update wasmtime requirement from 26 to 27 ([#183](https://github.com/grafana/augurs/pull/183))
-- use u32 instead of i32 for lower/upper windows ([#177](https://github.com/grafana/augurs/pull/177))
 
 ## [0.6.3](https://github.com/grafana/augurs/compare/augurs-prophet-v0.6.2...augurs-prophet-v0.6.3) - 2024-11-20
 

--- a/crates/augurs-seasons/CHANGELOG.md
+++ b/crates/augurs-seasons/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/grafana/augurs/compare/augurs-seasons-v0.6.3...augurs-seasons-v0.7.0) - 2024-11-25
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.6.3](https://github.com/grafana/augurs/compare/augurs-seasons-v0.6.2...augurs-seasons-v0.6.3) - 2024-11-20
 
 ### Other


### PR DESCRIPTION
## 🤖 New release
* `augurs`: 0.6.3 -> 0.7.0
* `augurs-changepoint`: 0.6.3 -> 0.7.0 (✓ API compatible changes)
* `augurs-core`: 0.6.3 -> 0.7.0
* `augurs-clustering`: 0.6.3 -> 0.7.0
* `augurs-dtw`: 0.6.3 -> 0.7.0
* `augurs-ets`: 0.6.3 -> 0.7.0 (✓ API compatible changes)
* `augurs-mstl`: 0.6.3 -> 0.7.0 (✓ API compatible changes)
* `augurs-forecaster`: 0.6.3 -> 0.7.0 (✓ API compatible changes)
* `augurs-outlier`: 0.6.3 -> 0.7.0 (✓ API compatible changes)
* `augurs-prophet`: 0.6.3 -> 0.7.0 (⚠️ API breaking changes)
* `augurs-seasons`: 0.6.3 -> 0.7.0 (✓ API compatible changes)

### ⚠️ `augurs-prophet` breaking changes

```
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/inherent_method_missing.ron

Failed in:
  Holiday::with_lower_window, previously in file /tmp/.tmpOOOHq5/augurs-prophet/src/features.rs:42
  Holiday::with_upper_window, previously in file /tmp/.tmpOOOHq5/augurs-prophet/src/features.rs:61
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `augurs`
<blockquote>

## [0.6.0](https://github.com/grafana/augurs/compare/augurs-v0.5.4...augurs-v0.6.0) - 2024-11-08

### Added

- add wasmtime based optimizer for dependency-free Rust impl
</blockquote>

## `augurs-changepoint`
<blockquote>

## [0.7.0](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.6.3...augurs-changepoint-v0.7.0) - 2024-11-25

### Other

- update Cargo.toml dependencies
</blockquote>

## `augurs-core`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-core-v0.5.0...augurs-core-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-clustering`
<blockquote>

## [0.5.2](https://github.com/grafana/augurs/compare/augurs-clustering-v0.5.1...augurs-clustering-v0.5.2) - 2024-10-25

### Other

- add benchmark for Prophet ([#140](https://github.com/grafana/augurs/pull/140))
</blockquote>

## `augurs-dtw`
<blockquote>

## [0.6.0](https://github.com/grafana/augurs/compare/augurs-dtw-v0.5.4...augurs-dtw-v0.6.0) - 2024-11-08

### Added

- [**breaking**] split JS package into separate crates ([#149](https://github.com/grafana/augurs/pull/149))
</blockquote>

## `augurs-ets`
<blockquote>

## [0.7.0](https://github.com/grafana/augurs/compare/augurs-ets-v0.6.3...augurs-ets-v0.7.0) - 2024-11-25

### Other

- update Cargo.toml dependencies
</blockquote>

## `augurs-mstl`
<blockquote>

## [0.7.0](https://github.com/grafana/augurs/compare/augurs-mstl-v0.6.3...augurs-mstl-v0.7.0) - 2024-11-25

### Other

- update Cargo.toml dependencies
</blockquote>

## `augurs-forecaster`
<blockquote>

## [0.7.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.6.3...augurs-forecaster-v0.7.0) - 2024-11-25

### Other

- update Cargo.toml dependencies
</blockquote>

## `augurs-outlier`
<blockquote>

## [0.7.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.6.3...augurs-outlier-v0.7.0) - 2024-11-25

### Other

- update Cargo.toml dependencies
</blockquote>

## `augurs-prophet`
<blockquote>

## [0.7.0](https://github.com/grafana/augurs/compare/augurs-prophet-v0.6.3...augurs-prophet-v0.7.0) - 2024-11-25

### Added

- feat!(prophet): support sub-daily & non-UTC holidays ([#181](https://github.com/grafana/augurs/pull/181))

### Fixed

- add a separate feature for each holiday's lower/upper windows ([#179](https://github.com/grafana/augurs/pull/179))

### Other

- *(deps)* update thiserror requirement from 1.0.40 to 2.0.3 ([#164](https://github.com/grafana/augurs/pull/164))
- *(deps)* update wasmtime requirement from 26 to 27 ([#183](https://github.com/grafana/augurs/pull/183))
- use u32 instead of i32 for lower/upper windows ([#177](https://github.com/grafana/augurs/pull/177))
</blockquote>

## `augurs-seasons`
<blockquote>

## [0.7.0](https://github.com/grafana/augurs/compare/augurs-seasons-v0.6.3...augurs-seasons-v0.7.0) - 2024-11-25

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated workspace package version to `0.7.0`, enhancing overall functionality.
	- Introduced support for sub-daily and non-UTC holidays in the augurs-prophet package.
- **Bug Fixes**
	- Fixed issues related to holiday feature windows in the augurs-prophet package.
- **Documentation**
	- Updated changelogs across multiple packages to reflect version `0.7.0` and dependency updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->