### PR TITLE
 fix: add a separate feature for each holiday's lower/upper windows

### DIFF
--- a/crates/augurs-prophet/src/prophet/prep.rs
+++ b/crates/augurs-prophet/src/prophet/prep.rs
@@ -121,7 +121,7 @@ impl ComponentColumns {
 }
 
 /// The name of a feature column in the `X` matrix passed to Stan.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(super) enum FeatureName {
     /// A seasonality feature.
     Seasonality {
@@ -660,6 +660,14 @@ impl<O> Prophet<O> {
     ) -> HashSet<String> {
         let mut holiday_names = HashSet::with_capacity(holidays.len());
         for (name, holiday) in holidays {
+            // Keep track of holiday columns here. Use a Vec and a HashMap to
+            // preserve order.
+            // For each day surrounding the holiday (decided by the lower and upper windows),
+            // plus the holiday itself, we want to create a new feature which is 0.0 for all
+            // days except that day, and 1.0 for that day.
+            let mut this_holiday_feature_names = Vec::new();
+            let mut this_holiday_features: HashMap<FeatureName, Vec<f64>> = HashMap::new();
+
             // Default to a window of 0 days either side.
             let lower = holiday
                 .lower_window
@@ -691,7 +699,12 @@ impl<O> Prophet<O> {
                         name: name.clone(),
                         _offset: offset,
                     };
-                    let mut col = vec![0.0; ds.len()];
+                    let col = this_holiday_features
+                        .entry(col_name.clone())
+                        .or_insert_with(|| {
+                            this_holiday_feature_names.push(col_name);
+                            vec![0.0; ds.len()]
+                        });
 
                     // Get the indices of the ds column that are 'on holiday'.
                     // Set the value of the holiday column 1.0 for those dates.
@@ -701,15 +714,20 @@ impl<O> Prophet<O> {
                     {
                         col[loc] = 1.0;
                     }
-                    // Add the holiday column to the features frame, and add a corresponding
-                    // prior scale.
-                    features.push(col_name, col);
-                    prior_scales.push(
-                        holiday
-                            .prior_scale
-                            .unwrap_or(self.opts.holidays_prior_scale),
-                    );
                 }
+            }
+            // Add the holiday column to the features frame, and add a corresponding
+            // prior scale.
+            for col_name in this_holiday_feature_names {
+                features.push(
+                    col_name.clone(),
+                    this_holiday_features.remove(&col_name).unwrap(),
+                );
+                prior_scales.push(
+                    holiday
+                        .prior_scale
+                        .unwrap_or(self.opts.holidays_prior_scale),
+                );
             }
             holiday_names.insert(name.clone());
             modes.insert(


### PR DESCRIPTION
Reading through the original Prophet Python code, it looks like we're
supposed to add a single feature for each value in the window of each
holiday, rather than a separate feature every time the holiday occurs.
This commit does so by creating a map of features and updating the
relevant column in the map while iterating over the holidays
occurrences.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced holiday feature handling for improved organization and clarity in data processing.
	- Introduced a new structure for managing holiday feature vectors using a HashMap.

- **Bug Fixes**
	- Maintained existing error handling for missing regressors and seasonality conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->