### PR TITLE
chore: release v0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ authors = [
 ]
 documentation = "https://docs.rs/crate/augurs"
 repository = "https://github.com/grafana/augurs"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 keywords = [
   "analysis",
@@ -29,16 +29,16 @@ keywords = [
 
 [workspace.dependencies]
 augurs = { path = "crates/augurs" }
-augurs-changepoint = { version = "0.7.0", path = "crates/augurs-changepoint" }
-augurs-clustering = { version = "0.7.0", path = "crates/augurs-clustering" }
-augurs-core = { version = "0.7.0", path = "crates/augurs-core" }
-augurs-dtw = { version = "0.7.0", path = "crates/augurs-dtw" }
-augurs-ets = { version = "0.7.0", path = "crates/augurs-ets" }
-augurs-forecaster = { version = "0.7.0", path = "crates/augurs-forecaster" }
-augurs-mstl = { version = "0.7.0", path = "crates/augurs-mstl" }
-augurs-outlier = { version = "0.7.0", path = "crates/augurs-outlier" }
-augurs-prophet = { version = "0.7.0", path = "crates/augurs-prophet" }
-augurs-seasons = { version = "0.7.0", path = "crates/augurs-seasons" }
+augurs-changepoint = { version = "0.8.0", path = "crates/augurs-changepoint" }
+augurs-clustering = { version = "0.8.0", path = "crates/augurs-clustering" }
+augurs-core = { version = "0.8.0", path = "crates/augurs-core" }
+augurs-dtw = { version = "0.8.0", path = "crates/augurs-dtw" }
+augurs-ets = { version = "0.8.0", path = "crates/augurs-ets" }
+augurs-forecaster = { version = "0.8.0", path = "crates/augurs-forecaster" }
+augurs-mstl = { version = "0.8.0", path = "crates/augurs-mstl" }
+augurs-outlier = { version = "0.8.0", path = "crates/augurs-outlier" }
+augurs-prophet = { version = "0.8.0", path = "crates/augurs-prophet" }
+augurs-seasons = { version = "0.8.0", path = "crates/augurs-seasons" }
 augurs-testing = { path = "crates/augurs-testing" }
 
 augurs-core-js = { path = "js/augurs-core-js" }

--- a/crates/augurs-forecaster/CHANGELOG.md
+++ b/crates/augurs-forecaster/CHANGELOG.md
@@ -6,6 +6,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.7.0...augurs-forecaster-v0.8.0) - 2024-12-16
+
+### Added
+
+- add 'transforms' JS crate and include in augurs JS bindings (#195)
+
+### Fixed
+
+- make Transform enum non-exhaustive (#194)
+
+### Other
+
+- precalculate offset and scale factor for min-max scale transformer (#196)
+- Add power transformation logic to forecaster transforms ([#185](https://github.com/grafana/augurs/pull/185))
+
 ## [0.7.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.6.3...augurs-forecaster-v0.7.0) - 2024-11-25
 
 ### Other

--- a/crates/augurs-prophet/CHANGELOG.md
+++ b/crates/augurs-prophet/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/grafana/augurs/compare/augurs-prophet-v0.7.0...augurs-prophet-v0.8.0) - 2024-12-16
+
+### Added
+
+- add Forecaster wrapper for Prophet (#191)
+
+### Fixed
+
+- add explicit link to chrono method (#192)
+
+### Other
+
+- *(deps)* update statrs requirement from 0.17.1 to 0.18.0 (#187)
+
 ## [0.7.0](https://github.com/grafana/augurs/compare/augurs-prophet-v0.6.3...augurs-prophet-v0.7.0) - 2024-11-25
 
 ### Breaking Changes


### PR DESCRIPTION
## 🤖 New release
* `augurs`: 0.7.0 -> 0.8.0
* `augurs-changepoint`: 0.7.0 -> 0.8.0
* `augurs-core`: 0.7.0 -> 0.8.0
* `augurs-clustering`: 0.7.0 -> 0.8.0
* `augurs-dtw`: 0.7.0 -> 0.8.0
* `augurs-ets`: 0.7.0 -> 0.8.0
* `augurs-mstl`: 0.7.0 -> 0.8.0
* `augurs-forecaster`: 0.7.0 -> 0.8.0 (⚠️ API breaking changes)
* `augurs-outlier`: 0.7.0 -> 0.8.0
* `augurs-prophet`: 0.7.0 -> 0.8.0 (✓ API compatible changes)
* `augurs-seasons`: 0.7.0 -> 0.8.0

### ⚠️ `augurs-forecaster` breaking changes

```
--- failure enum_marked_non_exhaustive: enum marked #[non_exhaustive] ---

Description:
A public enum has been marked #[non_exhaustive]. Pattern-matching on it outside of its crate must now include a wildcard pattern like `_`, or it will fail to compile.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#attr-adding-non-exhaustive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.37.0/src/lints/enum_marked_non_exhaustive.ron

Failed in:
  enum Transform in /tmp/.tmpjdcWYF/augurs/crates/augurs-forecaster/src/transforms.rs:48
  enum Transform in /tmp/.tmpjdcWYF/augurs/crates/augurs-forecaster/src/transforms.rs:48
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `augurs`
<blockquote>

## [0.6.0](https://github.com/grafana/augurs/compare/augurs-v0.5.4...augurs-v0.6.0) - 2024-11-08

### Added

- add wasmtime based optimizer for dependency-free Rust impl
</blockquote>

## `augurs-changepoint`
<blockquote>

## [0.7.0](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.6.3...augurs-changepoint-v0.7.0) - 2024-11-25

### Other

- update Cargo.toml dependencies
</blockquote>

## `augurs-core`
<blockquote>

## [0.5.1](https://github.com/grafana/augurs/compare/augurs-core-v0.5.0...augurs-core-v0.5.1) - 2024-10-24

### Other

- define lints in Cargo.toml instead of each crate's lib.rs ([#138](https://github.com/grafana/augurs/pull/138))
</blockquote>

## `augurs-clustering`
<blockquote>

## [0.5.2](https://github.com/grafana/augurs/compare/augurs-clustering-v0.5.1...augurs-clustering-v0.5.2) - 2024-10-25

### Other

- add benchmark for Prophet ([#140](https://github.com/grafana/augurs/pull/140))
</blockquote>

## `augurs-dtw`
<blockquote>

## [0.6.0](https://github.com/grafana/augurs/compare/augurs-dtw-v0.5.4...augurs-dtw-v0.6.0) - 2024-11-08

### Added

- [**breaking**] split JS package into separate crates ([#149](https://github.com/grafana/augurs/pull/149))
</blockquote>

## `augurs-ets`
<blockquote>

## [0.7.0](https://github.com/grafana/augurs/compare/augurs-ets-v0.6.3...augurs-ets-v0.7.0) - 2024-11-25

### Other

- update Cargo.toml dependencies
</blockquote>

## `augurs-mstl`
<blockquote>

## [0.7.0](https://github.com/grafana/augurs/compare/augurs-mstl-v0.6.3...augurs-mstl-v0.7.0) - 2024-11-25

### Other

- update Cargo.toml dependencies
</blockquote>

## `augurs-forecaster`
<blockquote>

## [0.8.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.7.0...augurs-forecaster-v0.8.0) - 2024-12-16

### Added

- add 'transforms' JS crate and include in augurs JS bindings (#195)

### Fixed

- make Transform enum non-exhaustive (#194)

### Other

- precalculate offset and scale factor for min-max scale transformer (#196)
- Add power transformation logic to forecaster transforms ([#185](https://github.com/grafana/augurs/pull/185))
</blockquote>

## `augurs-outlier`
<blockquote>

## [0.7.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.6.3...augurs-outlier-v0.7.0) - 2024-11-25

### Other

- update Cargo.toml dependencies
</blockquote>

## `augurs-prophet`
<blockquote>

## [0.8.0](https://github.com/grafana/augurs/compare/augurs-prophet-v0.7.0...augurs-prophet-v0.8.0) - 2024-12-16

### Added

- add Forecaster wrapper for Prophet (#191)

### Fixed

- add explicit link to chrono method (#192)

### Other

- *(deps)* update statrs requirement from 0.17.1 to 0.18.0 (#187)
</blockquote>

## `augurs-seasons`
<blockquote>

## [0.7.0](https://github.com/grafana/augurs/compare/augurs-seasons-v0.6.3...augurs-seasons-v0.7.0) - 2024-11-25

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).