### PR TITLE
fix: make Transform enum non-exhaustive

### DIFF
--- a/crates/augurs-forecaster/src/transforms.rs
+++ b/crates/augurs-forecaster/src/transforms.rs
@@ -44,6 +44,7 @@ impl Transforms {
 
 /// A transformation that can be applied to a time series.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Transform {
     /// Linear interpolation.
     ///


### PR DESCRIPTION
Happily, cargo-semver-checks caught the addition of some variants
in #185, but it's a shame that had to be a minor bump. This marks
the enum as non-exhaustive so future transform additions won't
necessarily be considered breaking changes. It's unlikely users
will ever have to match on this anyway so this shouldn't cause
any problems (it could probably be a struct with an 'inner'
enum, really).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `Transform` enum to allow for future extensions without breaking existing implementations.
	- Improved error handling in the `power_transform` method for better robustness during transformation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->