### PR TITLE
fix(build): add `project.dynamic = ["version"]` to pyaugurs pyproject.toml

### DIFF
--- a/crates/pyaugurs/pyproject.toml
+++ b/crates/pyaugurs/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "augurs"
+dynamic = ["version"]
 dependencies = ["numpy"]
 requires-python = ">=3.9"
 classifiers = [


### PR DESCRIPTION
uv is now failing to install packages which don't do this, and the spec
does require it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a dynamic versioning capability for the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->