### PR TITLE
fix: use box_cox instead of boxcox

### DIFF
--- a/crates/augurs-forecaster/src/transforms.rs
+++ b/crates/augurs-forecaster/src/transforms.rs
@@ -114,7 +114,7 @@ impl Transform {
     ///
     /// - if lambda == 0: x.ln()
     /// - otherwise: (x^lambda - 1) / lambda
-    pub fn boxcox(lambda: f64) -> Self {
+    pub fn box_cox(lambda: f64) -> Self {
         Self::BoxCox { lambda }
     }
 


### PR DESCRIPTION
For consistency.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Renamed the Box-Cox transformation method for consistency in naming conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->