### PR TITLE
feat: invert power transform/scaling order

### DIFF
--- a/crates/augurs-forecaster/src/transforms.rs
+++ b/crates/augurs-forecaster/src/transforms.rs
@@ -43,7 +43,7 @@ impl Transforms {
 }
 
 /// A transformation that can be applied to a time series.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[non_exhaustive]
 pub enum Transform {
     /// Linear interpolation.


### PR DESCRIPTION
On `main` we power transform then standard scale the results, matching sklearn. This PR tries out scaling then power transforming instead.