### PR TITLE
Update contributing.md to include additional steps

### DIFF
--- a/book/src/contributing.md
+++ b/book/src/contributing.md
@@ -17,15 +17,20 @@ There are many ways to contribute:
 1. Fork and clone the repository
 2. Install Rust via rustup if you haven't already
 3. Install [`just`][just] for running tasks
-4. Build the WASM component:
+4. Install [`cargo-binstall`][binstall] to install dependencies
+5. Install dependencies:
+```bash
+(cd components && just install-deps)
+```
+6. Build the WASM component:
 ```bash
 just build-component
 ```
-5. Start building and checking the project using [bacon]:
+7. Start building and checking the project using [bacon]:
 ```bash
-just build
+just watch
 ```
-6. Run tests:
+8. Run tests using [nextest]:
 ```bash
 just test
 ```
@@ -57,4 +62,6 @@ By contributing, you agree that your contributions will be licensed under the sa
 
 [repo]: https://github.com/grafana/augurs/
 [just]: https://just.systems/man/en/
+[binstall]: https://github.com/cargo-bins/cargo-binstall
 [bacon]: https://dystroy.org/bacon/
+[nextest]: https://nexte.st/

--- a/components/justfile
+++ b/components/justfile
@@ -1,4 +1,5 @@
 TOOLS_DIR := "./tools"
+WIT_BINDGEN_VERSION := "0.34.0"
 WASI_ARCH := `uname -m`
 WASI_OS := os()
 WASI_VERSION := "24"
@@ -15,7 +16,7 @@ checkout-submodules:
 # Install dependencies to work with WASI.
 install-deps: checkout-submodules
   cargo binstall -y cargo-component
-  cargo binstall -y wit-bindgen-cli
+  cargo binstall -y wit-bindgen-cli@{{WIT_BINDGEN_VERSION}}
   cargo binstall -y wasm-tools
   cargo binstall -y wac-cli
   curl https://wasmtime.dev/install.sh -sSf | bash


### PR DESCRIPTION
I ran into some additional necessary dependencies to install before I could run the project. In addition, pin wit-bindgen-cli to a specific version to avoid unnecessary diffs in generated files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the `contributing.md` file to enhance clarity and improve the contribution process, including new steps for development setup and updated commands for building and testing.

- **New Features**
	- Introduced a new variable `WIT_BINDGEN_VERSION` for flexible dependency management in the installation process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->