### PR TITLE
feat: allow creating a Box-Cox or Yeo-Johnson transform with either lambda or data

### DIFF
--- a/crates/augurs-forecaster/src/transforms/power.rs
+++ b/crates/augurs-forecaster/src/transforms/power.rs
@@ -352,6 +352,46 @@ pub(crate) trait InverseYeoJohnsonExt: Iterator<Item = f64> {
 
 impl<T> InverseYeoJohnsonExt for T where T: Iterator<Item = f64> {}
 
+/// A trait for types that can be used as the `lambda` parameter for the
+/// `Transform::box_cox` method.
+pub trait IntoBoxCoxLambda {
+    fn into_box_cox_lambda(self) -> Result<f64, Error>;
+}
+
+impl IntoBoxCoxLambda for f64 {
+    /// Use the given lambda parameter.
+    fn into_box_cox_lambda(self) -> Result<f64, Error> {
+        Ok(self)
+    }
+}
+
+impl IntoBoxCoxLambda for &[f64] {
+    /// Find the optimal Box-Cox lambda parameter using maximum likelihood estimation.
+    fn into_box_cox_lambda(self) -> Result<f64, Error> {
+        optimize_box_cox_lambda(self)
+    }
+}
+
+/// A trait for types that can be used as the `lambda` parameter for the
+/// `Transform::box_cox` method.
+pub trait IntoYeoJohnsonLambda {
+    fn into_yeo_johnson_lambda(self) -> Result<f64, Error>;
+}
+
+impl IntoYeoJohnsonLambda for f64 {
+    /// Use the given lambda parameter.
+    fn into_yeo_johnson_lambda(self) -> Result<f64, Error> {
+        Ok(self)
+    }
+}
+
+impl IntoYeoJohnsonLambda for &[f64] {
+    /// Find the optimal Yeo-Johnson lambda parameter using maximum likelihood estimation.
+    fn into_yeo_johnson_lambda(self) -> Result<f64, Error> {
+        optimize_yeo_johnson_lambda(self)
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;


### PR DESCRIPTION
This makes the Transform::box_cox and Transform::yeo_johnson constructors more flexible; users can either pass lambda directly or pass some data which will be used to find the optimal lambda.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced flexibility for Box-Cox and Yeo-Johnson transformations to accept both single values and slices.
	- Introduced new traits for obtaining lambda parameters, improving input versatility for transformation methods.

- **Bug Fixes**
	- Improved error handling for transformation methods to manage potential optimization failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->