### PR TITLE
chore: release v0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ authors = [
 ]
 documentation = "https://docs.rs/crate/augurs"
 repository = "https://github.com/grafana/augurs"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 keywords = [
   "analysis",
@@ -29,16 +29,16 @@ keywords = [
 
 [workspace.dependencies]
 augurs = { path = "crates/augurs" }
-augurs-changepoint = { version = "0.7.0", path = "crates/augurs-changepoint" }
-augurs-clustering = { version = "0.7.0", path = "crates/augurs-clustering" }
-augurs-core = { version = "0.7.0", path = "crates/augurs-core" }
-augurs-dtw = { version = "0.7.0", path = "crates/augurs-dtw" }
-augurs-ets = { version = "0.7.0", path = "crates/augurs-ets" }
-augurs-forecaster = { version = "0.7.0", path = "crates/augurs-forecaster" }
-augurs-mstl = { version = "0.7.0", path = "crates/augurs-mstl" }
-augurs-outlier = { version = "0.7.0", path = "crates/augurs-outlier" }
-augurs-prophet = { version = "0.7.0", path = "crates/augurs-prophet" }
-augurs-seasons = { version = "0.7.0", path = "crates/augurs-seasons" }
+augurs-changepoint = { version = "0.8.0", path = "crates/augurs-changepoint" }
+augurs-clustering = { version = "0.8.0", path = "crates/augurs-clustering" }
+augurs-core = { version = "0.8.0", path = "crates/augurs-core" }
+augurs-dtw = { version = "0.8.0", path = "crates/augurs-dtw" }
+augurs-ets = { version = "0.8.0", path = "crates/augurs-ets" }
+augurs-forecaster = { version = "0.8.0", path = "crates/augurs-forecaster" }
+augurs-mstl = { version = "0.8.0", path = "crates/augurs-mstl" }
+augurs-outlier = { version = "0.8.0", path = "crates/augurs-outlier" }
+augurs-prophet = { version = "0.8.0", path = "crates/augurs-prophet" }
+augurs-seasons = { version = "0.8.0", path = "crates/augurs-seasons" }
 augurs-testing = { path = "crates/augurs-testing" }
 
 augurs-core-js = { path = "js/augurs-core-js" }

--- a/crates/augurs-core/CHANGELOG.md
+++ b/crates/augurs-core/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/grafana/augurs/compare/augurs-core-v0.7.0...augurs-core-v0.8.0) - 2024-12-23
+
+### Added
+
+- [**breaking**] switch `transform` to a trait (#213)
+
 ## [0.5.1](https://github.com/grafana/augurs/compare/augurs-core-v0.5.0...augurs-core-v0.5.1) - 2024-10-24
 
 ### Other

--- a/crates/augurs-forecaster/CHANGELOG.md
+++ b/crates/augurs-forecaster/CHANGELOG.md
@@ -6,6 +6,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.7.0...augurs-forecaster-v0.8.0) - 2024-12-23
+
+### Added
+
+- [**breaking**] switch `transform` to a trait (#213)
+- allow creating a Box-Cox or Yeo-Johnson transform with either lambda or data (#212)
+- add standard scaler transform (#204)
+- add 'transforms' JS crate and include in augurs JS bindings (#195)
+
+### Fixed
+
+- use box_cox instead of boxcox (#203)
+- make Transform enum non-exhaustive (#194)
+
+### Other
+
+- restructure transforms into modules (#210)
+- precalculate offset and scale factor for min-max scale transformer (#196)
+- Add power transformation logic to forecaster transforms ([#185](https://github.com/grafana/augurs/pull/185))
+
 ## [0.7.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.6.3...augurs-forecaster-v0.7.0) - 2024-11-25
 
 ### Other

--- a/crates/augurs-forecaster/CHANGELOG.md
+++ b/crates/augurs-forecaster/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.7.0...augurs-forecaster-v0.8.0) - 2024-12-23
 
+This release includes some major, breaking changes to the `augurs-forecaster` crate. See the [migration guide](https://docs.augu.rs/migrating.html#from-07-to-08) for more information on how to upgrade.
+
 ### Added
 
 - [**breaking**] switch `transform` to a trait (#213)
@@ -27,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add power transformation logic to forecaster transforms ([#185](https://github.com/grafana/augurs/pull/185))
 
 ## [0.7.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.6.3...augurs-forecaster-v0.7.0) - 2024-11-25
+
+This release includes some major, breaking changes to how holidays are handled in Prophet. See the [migration guide](https://docs.augu.rs/migrating.html#from-06-to-07) for more information on how to upgrade.
 
 ### Other
 

--- a/crates/augurs-outlier/CHANGELOG.md
+++ b/crates/augurs-outlier/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.7.0...augurs-outlier-v0.8.0) - 2024-12-23
+
+### Other
+
+- *(deps)* update rv requirement from 0.17.0 to 0.18.0 (#198)
+
 ## [0.7.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.6.3...augurs-outlier-v0.7.0) - 2024-11-25
 
 ### Other

--- a/crates/augurs-prophet/CHANGELOG.md
+++ b/crates/augurs-prophet/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.7.0](https://github.com/grafana/augurs/compare/augurs-prophet-v0.6.3...augurs-prophet-v0.7.0) - 2024-11-25
 
+This release includes some major, breaking changes to how holidays are handled. See the [migration guide](https://docs.augu.rs/migrating.html#from-06-to-07) for more information on how to upgrade.
+
 ### Breaking Changes
 
 - Support sub-daily & non-UTC holidays ([#181](https://github.com/grafana/augurs/pull/181))

--- a/crates/augurs-prophet/CHANGELOG.md
+++ b/crates/augurs-prophet/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/grafana/augurs/compare/augurs-prophet-v0.7.0...augurs-prophet-v0.8.0) - 2024-12-23
+
+### Added
+
+- add Forecaster wrapper for Prophet (#191)
+
+### Fixed
+
+- fix filtering of NaNs in Prophet preprocessing (#219)
+- *(docs)* fix incorrect link to chrono
+- add explicit link to chrono method (#192)
+
+### Other
+
+- *(deps)* update wasmtime requirement from 27 to 28 (#216)
+- Commit prophet-wasmstan.wasm to git ([#206](https://github.com/grafana/augurs/pull/206))
+- *(deps)* update statrs requirement from 0.17.1 to 0.18.0 (#187)
+
 ## [0.7.0](https://github.com/grafana/augurs/compare/augurs-prophet-v0.6.3...augurs-prophet-v0.7.0) - 2024-11-25
 
 ### Breaking Changes

--- a/crates/augurs/CHANGELOG.md
+++ b/crates/augurs/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.0](https://github.com/grafana/augurs/compare/augurs-v0.7.0...augurs-v0.8.0) - 2024-12-23
 
+This release includes some major, breaking changes to the `augurs-forecaster` crate (and the `forecaster` feature of the `augurs` crate). See the [migration guide](https://docs.augu.rs/migrating.html#from-07-to-08) for more information on how to upgrade.
+
 ### Added
 
 - [**breaking**] switch `transform` to a trait (#213)

--- a/crates/augurs/CHANGELOG.md
+++ b/crates/augurs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/grafana/augurs/compare/augurs-v0.7.0...augurs-v0.8.0) - 2024-12-23
+
+### Added
+
+- [**breaking**] switch `transform` to a trait (#213)
+
 ## [0.6.0](https://github.com/grafana/augurs/compare/augurs-v0.5.4...augurs-v0.6.0) - 2024-11-08
 
 ### Added


### PR DESCRIPTION
## 🤖 New release
* `augurs`: 0.7.0 -> 0.8.0 (✓ API compatible changes)
* `augurs-changepoint`: 0.7.0 -> 0.8.0
* `augurs-core`: 0.7.0 -> 0.8.0 (⚠️ API breaking changes)
* `augurs-clustering`: 0.7.0 -> 0.8.0
* `augurs-dtw`: 0.7.0 -> 0.8.0
* `augurs-ets`: 0.7.0 -> 0.8.0
* `augurs-mstl`: 0.7.0 -> 0.8.0
* `augurs-forecaster`: 0.7.0 -> 0.8.0 (⚠️ API breaking changes)
* `augurs-outlier`: 0.7.0 -> 0.8.0 (✓ API compatible changes)
* `augurs-prophet`: 0.7.0 -> 0.8.0 (✓ API compatible changes)
* `augurs-seasons`: 0.7.0 -> 0.8.0

### ⚠️ `augurs-core` breaking changes

```
--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/module_missing.ron

Failed in:
  mod augurs_core::interpolate, previously in file /tmp/.tmp4YShem/augurs-core/src/interpolate.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/struct_missing.ron

Failed in:
  struct augurs_core::interpolate::LinearInterpolator, previously in file /tmp/.tmp4YShem/augurs-core/src/interpolate.rs:41
  struct augurs_core::interpolate::Interpolate, previously in file /tmp/.tmp4YShem/augurs-core/src/interpolate.rs:71

--- failure trait_missing: pub trait removed or renamed ---

Description:
A publicly-visible trait cannot be imported by its prior path. A `pub use` may have been removed, or the trait itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/trait_missing.ron

Failed in:
  trait augurs_core::interpolate::Interpolater, previously in file /tmp/.tmp4YShem/augurs-core/src/interpolate.rs:16
  trait augurs_core::interpolate::InterpolateExt, previously in file /tmp/.tmp4YShem/augurs-core/src/interpolate.rs:159
  trait augurs_core::interpolate::Interpolatable, previously in file /tmp/.tmp4YShem/augurs-core/src/interpolate.rs:198
```

### ⚠️ `augurs-forecaster` breaking changes

```
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type Forecaster is no longer UnwindSafe, in /tmp/.tmpjZCN0q/augurs/crates/augurs-forecaster/src/forecaster.rs:12
  type Forecaster is no longer RefUnwindSafe, in /tmp/.tmpjZCN0q/augurs/crates/augurs-forecaster/src/forecaster.rs:12

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_missing.ron

Failed in:
  enum augurs_forecaster::transforms::Transform, previously in file /tmp/.tmp4YShem/augurs-forecaster/src/transforms.rs:37
  enum augurs_forecaster::Transform, previously in file /tmp/.tmp4YShem/augurs-forecaster/src/transforms.rs:37

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/enum_variant_added.ron

Failed in:
  variant Error:Transform in /tmp/.tmpjZCN0q/augurs/crates/augurs-forecaster/src/error.rs:26

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/inherent_method_missing.ron

Failed in:
  Forecaster::with_transforms, previously in file /tmp/.tmp4YShem/augurs-forecaster/src/forecaster.rs:34

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.38.0/src/lints/struct_missing.ron

Failed in:
  struct augurs_forecaster::transforms::MinMaxScaleParams, previously in file /tmp/.tmp4YShem/augurs-forecaster/src/transforms.rs:131
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `augurs`
<blockquote>

## [0.8.0](https://github.com/grafana/augurs/compare/augurs-v0.7.0...augurs-v0.8.0) - 2024-12-23

### Added

- [**breaking**] switch `transform` to a trait (#213)
</blockquote>

## `augurs-changepoint`
<blockquote>

## [0.7.0](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.6.3...augurs-changepoint-v0.7.0) - 2024-11-25

### Other

- update Cargo.toml dependencies
</blockquote>

## `augurs-core`
<blockquote>

## [0.8.0](https://github.com/grafana/augurs/compare/augurs-core-v0.7.0...augurs-core-v0.8.0) - 2024-12-23

### Added

- [**breaking**] switch `transform` to a trait (#213)
</blockquote>

## `augurs-clustering`
<blockquote>

## [0.5.2](https://github.com/grafana/augurs/compare/augurs-clustering-v0.5.1...augurs-clustering-v0.5.2) - 2024-10-25

### Other

- add benchmark for Prophet ([#140](https://github.com/grafana/augurs/pull/140))
</blockquote>

## `augurs-dtw`
<blockquote>

## [0.6.0](https://github.com/grafana/augurs/compare/augurs-dtw-v0.5.4...augurs-dtw-v0.6.0) - 2024-11-08

### Added

- [**breaking**] split JS package into separate crates ([#149](https://github.com/grafana/augurs/pull/149))
</blockquote>

## `augurs-ets`
<blockquote>

## [0.7.0](https://github.com/grafana/augurs/compare/augurs-ets-v0.6.3...augurs-ets-v0.7.0) - 2024-11-25

### Other

- update Cargo.toml dependencies
</blockquote>

## `augurs-mstl`
<blockquote>

## [0.7.0](https://github.com/grafana/augurs/compare/augurs-mstl-v0.6.3...augurs-mstl-v0.7.0) - 2024-11-25

### Other

- update Cargo.toml dependencies
</blockquote>

## `augurs-forecaster`
<blockquote>

## [0.8.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.7.0...augurs-forecaster-v0.8.0) - 2024-12-23

### Added

- [**breaking**] switch `transform` to a trait (#213)
- allow creating a Box-Cox or Yeo-Johnson transform with either lambda or data (#212)
- add standard scaler transform (#204)
- add 'transforms' JS crate and include in augurs JS bindings (#195)

### Fixed

- use box_cox instead of boxcox (#203)
- make Transform enum non-exhaustive (#194)

### Other

- restructure transforms into modules (#210)
- precalculate offset and scale factor for min-max scale transformer (#196)
- Add power transformation logic to forecaster transforms ([#185](https://github.com/grafana/augurs/pull/185))
</blockquote>

## `augurs-outlier`
<blockquote>

## [0.8.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.7.0...augurs-outlier-v0.8.0) - 2024-12-23

### Other

- *(deps)* update rv requirement from 0.17.0 to 0.18.0 (#198)
</blockquote>

## `augurs-prophet`
<blockquote>

## [0.8.0](https://github.com/grafana/augurs/compare/augurs-prophet-v0.7.0...augurs-prophet-v0.8.0) - 2024-12-23

### Added

- add Forecaster wrapper for Prophet (#191)

### Fixed

- fix filtering of NaNs in Prophet preprocessing (#219)
- *(docs)* fix incorrect link to chrono
- add explicit link to chrono method (#192)

### Other

- *(deps)* update wasmtime requirement from 27 to 28 (#216)
- Commit prophet-wasmstan.wasm to git ([#206](https://github.com/grafana/augurs/pull/206))
- *(deps)* update statrs requirement from 0.17.1 to 0.18.0 (#187)
</blockquote>

## `augurs-seasons`
<blockquote>

## [0.7.0](https://github.com/grafana/augurs/compare/augurs-seasons-v0.6.3...augurs-seasons-v0.7.0) - 2024-11-25

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated workspace version to 0.8.0, enhancing overall functionality.
	- Introduced new features in the forecaster, including Box-Cox and Yeo-Johnson transforms.
	- Added a Forecaster wrapper for Prophet.
  
- **Bug Fixes**
	- Corrected documentation links and improved NaN filtering in Prophet preprocessing.
	- Fixed issues with transform enum and dependency requirements.

- **Documentation**
	- Updated changelogs to reflect new version entries and significant changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->