### PR TITLE
fix: really fix filtering of NaNs this time

### DIFF
--- a/crates/augurs-prophet/src/prophet/prep.rs
+++ b/crates/augurs-prophet/src/prophet/prep.rs
@@ -195,6 +195,7 @@ pub(super) struct Features {
 
 impl<O> Prophet<O> {
     pub(super) fn preprocess(&mut self, data: TrainingData) -> Result<Preprocessed, Error> {
+        let data = data.filter_nans();
         let n = data.ds.len();
         if n != data.y.len() {
             return Err(Error::MismatchedLengths {
@@ -207,7 +208,6 @@ impl<O> Prophet<O> {
         if n < 2 {
             return Err(Error::NotEnoughData);
         }
-        let data = data.filter_nans();
 
         let mut history_dates = data.ds.clone();
         history_dates.sort_unstable();


### PR DESCRIPTION
Filter NaNs immediately in `preprocess`, before assigning `n`.

Includes an actual integration test using the Wasmstan optimizer.