### PR TITLE
chore: release v0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ authors = [
 ]
 documentation = "https://docs.rs/crate/augurs"
 repository = "https://github.com/grafana/augurs"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2021"
 keywords = [
   "analysis",
@@ -29,16 +29,16 @@ keywords = [
 
 [workspace.dependencies]
 augurs = { path = "crates/augurs" }
-augurs-changepoint = { version = "0.8.1", path = "crates/augurs-changepoint" }
-augurs-clustering = { version = "0.8.1", path = "crates/augurs-clustering" }
-augurs-core = { version = "0.8.1", path = "crates/augurs-core" }
-augurs-dtw = { version = "0.8.1", path = "crates/augurs-dtw" }
-augurs-ets = { version = "0.8.1", path = "crates/augurs-ets" }
-augurs-forecaster = { version = "0.8.1", path = "crates/augurs-forecaster" }
-augurs-mstl = { version = "0.8.1", path = "crates/augurs-mstl" }
-augurs-outlier = { version = "0.8.1", path = "crates/augurs-outlier" }
-augurs-prophet = { version = "0.8.1", path = "crates/augurs-prophet" }
-augurs-seasons = { version = "0.8.1", path = "crates/augurs-seasons" }
+augurs-changepoint = { version = "0.9.0", path = "crates/augurs-changepoint" }
+augurs-clustering = { version = "0.9.0", path = "crates/augurs-clustering" }
+augurs-core = { version = "0.9.0", path = "crates/augurs-core" }
+augurs-dtw = { version = "0.9.0", path = "crates/augurs-dtw" }
+augurs-ets = { version = "0.9.0", path = "crates/augurs-ets" }
+augurs-forecaster = { version = "0.9.0", path = "crates/augurs-forecaster" }
+augurs-mstl = { version = "0.9.0", path = "crates/augurs-mstl" }
+augurs-outlier = { version = "0.9.0", path = "crates/augurs-outlier" }
+augurs-prophet = { version = "0.9.0", path = "crates/augurs-prophet" }
+augurs-seasons = { version = "0.9.0", path = "crates/augurs-seasons" }
 augurs-testing = { path = "crates/augurs-testing" }
 
 augurs-core-js = { path = "js/augurs-core-js" }

--- a/crates/augurs-clustering/CHANGELOG.md
+++ b/crates/augurs-clustering/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/grafana/augurs/compare/augurs-clustering-v0.8.1...augurs-clustering-v0.9.0) - 2025-01-14
+
+### Other
+
+- *(clustering)* [**breaking**] use new DbscanCluster type instead of isize (#233)
+
 ## [0.5.2](https://github.com/grafana/augurs/compare/augurs-clustering-v0.5.1...augurs-clustering-v0.5.2) - 2024-10-25
 
 ### Other

--- a/crates/augurs-core/CHANGELOG.md
+++ b/crates/augurs-core/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/grafana/augurs/compare/augurs-core-v0.8.1...augurs-core-v0.9.0) - 2025-01-14
+
+### Added
+
+- *(forecaster)* add NaN handling to MinMaxScaler and StandardScaler (#227)
+
 ## [0.8.0](https://github.com/grafana/augurs/compare/augurs-core-v0.7.0...augurs-core-v0.8.0) - 2024-12-23
 
 ### Added

--- a/crates/augurs-dtw/CHANGELOG.md
+++ b/crates/augurs-dtw/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/grafana/augurs/compare/augurs-dtw-v0.8.1...augurs-dtw-v0.9.0) - 2025-01-14
+
+### Added
+
+- *(forecaster)* add NaN handling to MinMaxScaler and StandardScaler (#227)
+
 ## [0.8.1](https://github.com/grafana/augurs/compare/augurs-dtw-v0.8.0...augurs-dtw-v0.8.1) - 2025-01-07
 
 ### Other

--- a/crates/augurs-forecaster/CHANGELOG.md
+++ b/crates/augurs-forecaster/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.8.1...augurs-forecaster-v0.9.0) - 2025-01-14
+
+### Added
+
+- allow ignoring NaNs in power transforms (#234)
+- *(forecaster)* add NaN handling to MinMaxScaler and StandardScaler (#227)
+
 ## [0.8.1](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.8.0...augurs-forecaster-v0.8.1) - 2025-01-07
 
 ### Other

--- a/crates/augurs-outlier/CHANGELOG.md
+++ b/crates/augurs-outlier/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.8.1...augurs-outlier-v0.9.0) - 2025-01-14
+
+### Added
+
+- *(forecaster)* add NaN handling to MinMaxScaler and StandardScaler (#227)
+
 ## [0.8.1](https://github.com/grafana/augurs/compare/augurs-outlier-v0.8.0...augurs-outlier-v0.8.1) - 2025-01-07
 
 ### Other

--- a/crates/augurs-prophet/CHANGELOG.md
+++ b/crates/augurs-prophet/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/grafana/augurs/compare/augurs-prophet-v0.8.1...augurs-prophet-v0.9.0) - 2025-01-14
+
+### Added
+
+- *(forecaster)* add NaN handling to MinMaxScaler and StandardScaler (#227)
+
 ## [0.8.1](https://github.com/grafana/augurs/compare/augurs-prophet-v0.8.0...augurs-prophet-v0.8.1) - 2025-01-07
 
 ### Fixed

--- a/crates/augurs/CHANGELOG.md
+++ b/crates/augurs/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/grafana/augurs/compare/augurs-v0.8.1...augurs-v0.9.0) - 2025-01-14
+
+### Other
+
+- *(clustering)* [**breaking**] use new DbscanCluster type instead of isize (#233)
+
 ## [0.8.1](https://github.com/grafana/augurs/compare/augurs-v0.8.0...augurs-v0.8.1) - 2025-01-07
 
 ### Other


### PR DESCRIPTION
## 🤖 New release
* `augurs`: 0.8.1 -> 0.9.0 (✓ API compatible changes)
* `augurs-changepoint`: 0.8.1 -> 0.9.0
* `augurs-core`: 0.8.1 -> 0.9.0 (✓ API compatible changes)
* `augurs-clustering`: 0.8.1 -> 0.9.0 (✓ API compatible changes)
* `augurs-dtw`: 0.8.1 -> 0.9.0 (✓ API compatible changes)
* `augurs-ets`: 0.8.1 -> 0.9.0
* `augurs-mstl`: 0.8.1 -> 0.9.0
* `augurs-forecaster`: 0.8.1 -> 0.9.0 (✓ API compatible changes)
* `augurs-outlier`: 0.8.1 -> 0.9.0 (✓ API compatible changes)
* `augurs-prophet`: 0.8.1 -> 0.9.0 (✓ API compatible changes)
* `augurs-seasons`: 0.8.1 -> 0.9.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `augurs`
<blockquote>

## [0.9.0](https://github.com/grafana/augurs/compare/augurs-v0.8.1...augurs-v0.9.0) - 2025-01-14

### Other

- *(clustering)* [**breaking**] use new DbscanCluster type instead of isize (#233)
</blockquote>

## `augurs-changepoint`
<blockquote>

## [0.8.1](https://github.com/grafana/augurs/compare/augurs-changepoint-v0.8.0...augurs-changepoint-v0.8.1) - 2025-01-07

### Other

- update Cargo.toml dependencies
</blockquote>

## `augurs-core`
<blockquote>

## [0.9.0](https://github.com/grafana/augurs/compare/augurs-core-v0.8.1...augurs-core-v0.9.0) - 2025-01-14

### Added

- *(forecaster)* add NaN handling to MinMaxScaler and StandardScaler (#227)
</blockquote>

## `augurs-clustering`
<blockquote>

## [0.9.0](https://github.com/grafana/augurs/compare/augurs-clustering-v0.8.1...augurs-clustering-v0.9.0) - 2025-01-14

### Other

- *(clustering)* [**breaking**] use new DbscanCluster type instead of isize (#233)
</blockquote>

## `augurs-dtw`
<blockquote>

## [0.9.0](https://github.com/grafana/augurs/compare/augurs-dtw-v0.8.1...augurs-dtw-v0.9.0) - 2025-01-14

### Added

- *(forecaster)* add NaN handling to MinMaxScaler and StandardScaler (#227)
</blockquote>

## `augurs-ets`
<blockquote>

## [0.8.1](https://github.com/grafana/augurs/compare/augurs-ets-v0.8.0...augurs-ets-v0.8.1) - 2025-01-07

### Other

- update Cargo.toml dependencies
</blockquote>

## `augurs-mstl`
<blockquote>

## [0.7.0](https://github.com/grafana/augurs/compare/augurs-mstl-v0.6.3...augurs-mstl-v0.7.0) - 2024-11-25

### Other

- update Cargo.toml dependencies
</blockquote>

## `augurs-forecaster`
<blockquote>

## [0.9.0](https://github.com/grafana/augurs/compare/augurs-forecaster-v0.8.1...augurs-forecaster-v0.9.0) - 2025-01-14

### Added

- allow ignoring NaNs in power transforms (#234)
- *(forecaster)* add NaN handling to MinMaxScaler and StandardScaler (#227)
</blockquote>

## `augurs-outlier`
<blockquote>

## [0.9.0](https://github.com/grafana/augurs/compare/augurs-outlier-v0.8.1...augurs-outlier-v0.9.0) - 2025-01-14

### Added

- *(forecaster)* add NaN handling to MinMaxScaler and StandardScaler (#227)
</blockquote>

## `augurs-prophet`
<blockquote>

## [0.9.0](https://github.com/grafana/augurs/compare/augurs-prophet-v0.8.1...augurs-prophet-v0.9.0) - 2025-01-14

### Added

- *(forecaster)* add NaN handling to MinMaxScaler and StandardScaler (#227)
</blockquote>

## `augurs-seasons`
<blockquote>

## [0.8.1](https://github.com/grafana/augurs/compare/augurs-seasons-v0.8.0...augurs-seasons-v0.8.1) - 2025-01-07

### Other

- update Cargo.toml dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).