### PR TITLE
refactor(clustering)!: use new DbscanCluster type instead of isize

### DIFF
--- a/book/book.toml
+++ b/book/book.toml
@@ -4,3 +4,6 @@ language = "en"
 multilingual = false
 src = "src"
 title = "augurs - a time series toolkit"
+
+[rust]
+edition = "2021"

--- a/book/src/tutorials/clustering.md
+++ b/book/src/tutorials/clustering.md
@@ -14,7 +14,10 @@ Let's start with a simple example using DBSCAN clustering:
 
 ```rust
 # extern crate augurs;
-use augurs::{clustering::DbscanClusterer, dtw::Dtw};
+use augurs::{
+    clustering::{DbscanCluster, DbscanClusterer},
+    dtw::Dtw,
+};
 
 // Sample time series data
 const SERIES: &[&[f64]] = &[
@@ -39,11 +42,20 @@ fn main() {
     let min_cluster_size = 2;
 
     // Perform clustering
-    let clusters: Vec<isize> = DbscanClusterer::new(epsilon, min_cluster_size)
+    let clusters = DbscanClusterer::new(epsilon, min_cluster_size)
         .fit(&distance_matrix);
 
     // Clusters are labeled: -1 for noise, 0+ for cluster membership
-    assert_eq!(clusters, vec![0, 0, 1, 1, -1]);
+    assert_eq!(
+        clusters,
+        vec![
+            DbscanCluster::Cluster(1.try_into().unwrap()),
+            DbscanCluster::Cluster(1.try_into().unwrap()),
+            DbscanCluster::Cluster(2.try_into().unwrap()),
+            DbscanCluster::Cluster(2.try_into().unwrap()),
+            DbscanCluster::Noise,
+        ]
+    );
 }
 ```
 

--- a/crates/augurs-clustering/README.md
+++ b/crates/augurs-clustering/README.md
@@ -8,7 +8,7 @@ A crate such as [`augurs-dtw`] must be used to calculate the distance matrix for
 ## Usage
 
 ```rust
-use augurs::clustering::{DbscanClusterer, DistanceMatrix};
+use augurs::clustering::{DbscanCluster, DbscanClusterer, DistanceMatrix};
 
 # fn main() -> Result<(), Box<dyn std::error::Error>> {
 // Start with a distance matrix.
@@ -32,7 +32,16 @@ let min_cluster_size = 2;
 // Use DBSCAN to detect clusters of series.
 // Note that we don't need to specify the number of clusters in advance.
 let clusters = DbscanClusterer::new(epsilon, min_cluster_size).fit(&distance_matrix);
-assert_eq!(clusters, vec![0, 0, 0, 1, 1]);
+assert_eq!(
+    clusters,
+    vec![
+        DbscanCluster::Cluster(1.try_into().unwrap()),
+        DbscanCluster::Cluster(1.try_into().unwrap()),
+        DbscanCluster::Cluster(1.try_into().unwrap()),
+        DbscanCluster::Cluster(2.try_into().unwrap()),
+        DbscanCluster::Cluster(2.try_into().unwrap()),
+    ],
+);
 # Ok(())
 # }
 ```

--- a/crates/augurs/tests/integration.rs
+++ b/crates/augurs/tests/integration.rs
@@ -18,6 +18,9 @@ fn test_changepoint() {
 #[cfg(feature = "clustering")]
 #[test]
 fn test_clustering() {
+    fn convert_clusters(clusters: Vec<augurs_clustering::DbscanCluster>) -> Vec<i32> {
+        clusters.into_iter().map(|c| c.as_i32()).collect()
+    }
     use augurs::{clustering::DbscanClusterer, DistanceMatrix};
     let distance_matrix = vec![
         vec![0.0, 1.0, 2.0, 3.0],
@@ -27,22 +30,22 @@ fn test_clustering() {
     ];
     let distance_matrix = DistanceMatrix::try_from_square(distance_matrix).unwrap();
     let clusters = DbscanClusterer::new(0.5, 2).fit(&distance_matrix);
-    assert_eq!(clusters, vec![-1, -1, -1, -1]);
+    assert_eq!(convert_clusters(clusters), vec![-1, -1, -1, -1]);
 
     let clusters = DbscanClusterer::new(1.0, 2).fit(&distance_matrix);
-    assert_eq!(clusters, vec![0, 0, -1, -1]);
+    assert_eq!(convert_clusters(clusters), vec![1, 1, -1, -1]);
 
     let clusters = DbscanClusterer::new(1.0, 3).fit(&distance_matrix);
-    assert_eq!(clusters, vec![-1, -1, -1, -1]);
+    assert_eq!(convert_clusters(clusters), vec![-1, -1, -1, -1]);
 
     let clusters = DbscanClusterer::new(2.0, 2).fit(&distance_matrix);
-    assert_eq!(clusters, vec![0, 0, 0, -1]);
+    assert_eq!(convert_clusters(clusters), vec![1, 1, 1, -1]);
 
     let clusters = DbscanClusterer::new(2.0, 3).fit(&distance_matrix);
-    assert_eq!(clusters, vec![0, 0, 0, -1]);
+    assert_eq!(convert_clusters(clusters), vec![1, 1, 1, -1]);
 
     let clusters = DbscanClusterer::new(3.0, 3).fit(&distance_matrix);
-    assert_eq!(clusters, vec![0, 0, 0, 0]);
+    assert_eq!(convert_clusters(clusters), vec![1, 1, 1, 1]);
 }
 
 #[cfg(feature = "dtw")]

--- a/crates/pyaugurs/src/clustering.rs
+++ b/crates/pyaugurs/src/clustering.rs
@@ -82,8 +82,15 @@ impl Dbscan {
         &self,
         py: Python<'_>,
         distance_matrix: InputDistanceMatrix<'_>,
-    ) -> PyResult<Py<PyArray1<isize>>> {
+    ) -> PyResult<Py<PyArray1<i32>>> {
         let distance_matrix = distance_matrix.try_into()?;
-        Ok(self.inner.fit(&distance_matrix).into_pyarray(py).into())
+        Ok(self
+            .inner
+            .fit(&distance_matrix)
+            .into_iter()
+            .map(|x| x.as_i32())
+            .collect::<Vec<_>>()
+            .into_pyarray(py)
+            .into())
     }
 }

--- a/examples/clustering/examples/dbscan_clustering.rs
+++ b/examples/clustering/examples/dbscan_clustering.rs
@@ -7,7 +7,10 @@
 //! The resulting clusters are assigned a label of -1 for noise, 0 for the first cluster, and 1 for
 //! the second cluster.
 
-use augurs::{clustering::DbscanClusterer, dtw::Dtw};
+use augurs::{
+    clustering::{DbscanCluster, DbscanClusterer},
+    dtw::Dtw,
+};
 
 // This is a very trivial example dataset containing 5 time series which
 // form two obvious clusters, plus a noise cluster.
@@ -49,7 +52,16 @@ fn main() {
     let min_cluster_size = 2;
 
     // Run DBSCAN clustering on the distance matrix.
-    let clusters: Vec<isize> =
-        DbscanClusterer::new(epsilon, min_cluster_size).fit(&distance_matrix);
-    assert_eq!(clusters, vec![0, 0, 1, 1, -1]);
+    let clusters = DbscanClusterer::new(epsilon, min_cluster_size).fit(&distance_matrix);
+    println!("Clusters: {:?}", clusters);
+    assert_eq!(
+        clusters,
+        vec![
+            DbscanCluster::Cluster(1.try_into().unwrap()),
+            DbscanCluster::Cluster(1.try_into().unwrap()),
+            DbscanCluster::Cluster(2.try_into().unwrap()),
+            DbscanCluster::Cluster(2.try_into().unwrap()),
+            DbscanCluster::Noise,
+        ]
+    );
 }

--- a/js/augurs-clustering-js/src/lib.rs
+++ b/js/augurs-clustering-js/src/lib.rs
@@ -44,7 +44,12 @@ impl DbscanClusterer {
     /// The return value is an `Int32Array` of cluster IDs, with `-1` indicating noise.
     #[wasm_bindgen]
     #[allow(non_snake_case)]
-    pub fn fit(&self, distanceMatrix: VecVecF64) -> Result<Vec<isize>, JsError> {
-        Ok(self.inner.fit(&DistanceMatrix::new(distanceMatrix)?.into()))
+    pub fn fit(&self, distanceMatrix: VecVecF64) -> Result<Vec<i32>, JsError> {
+        Ok(self
+            .inner
+            .fit(&DistanceMatrix::new(distanceMatrix)?.into())
+            .into_iter()
+            .map(|x| x.as_i32())
+            .collect::<Vec<_>>())
     }
 }

--- a/js/testpkg/clustering.test.ts
+++ b/js/testpkg/clustering.test.ts
@@ -22,7 +22,7 @@ describe('clustering', () => {
       [2, 3, 0, 4],
       [3, 3, 4, 0],
     ]);
-    expect(labels).toEqual(new Int32Array([0, 0, -1, -1]));
+    expect(labels).toEqual(new Int32Array([1, 1, -1, -1]));
   });
 
   it('can be fit with a raw distance matrix of typed arrays', () => {
@@ -33,7 +33,7 @@ describe('clustering', () => {
       new Float64Array([2, 3, 0, 4]),
       new Float64Array([3, 3, 4, 0]),
     ]);
-    expect(labels).toEqual(new Int32Array([0, 0, -1, -1]));
+    expect(labels).toEqual(new Int32Array([1, 1, -1, -1]));
   });
 
   it('can be fit with a distance matrix from augurs', () => {
@@ -46,6 +46,6 @@ describe('clustering', () => {
     ]);
     const clusterer = new DbscanClusterer({ epsilon: 0.5, minClusterSize: 2 });
     const labels = clusterer.fit(distanceMatrix);
-    expect(labels).toEqual(new Int32Array([0, 0, 0, -1]));
+    expect(labels).toEqual(new Int32Array([1, 1, 1, -1]));
   })
 });


### PR DESCRIPTION
Add a new `DbscanCluster` type to represent the cluster labels, which
can be either a cluster ID or a special value indicating noise. The
`Cluster` variant is now a `NonZeroU32` instead of an `isize`.

We could use a `u32` but using a `NonZeroU32` allows us to make use
of the niche optimizations that `NonZeroU32` provides and halves the
size of the type. Questionable whether it's worth it though?

Closes #229.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `DbscanCluster` enum to provide a more structured representation of clustering results.
	- Added methods to manage cluster identification and noise detection.

- **Bug Fixes**
	- Improved cluster representation to ensure more robust and type-safe clustering output.

- **Refactor**
	- Updated clustering implementation to use new `DbscanCluster` type across multiple components.
	- Modified return types and assertions to work with the new cluster representation.
	- Enhanced test structure for clarity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->