### PR TITLE
feat: allow ignoring NaNs in power transforms

### DIFF
--- a/crates/augurs-forecaster/src/transforms/error.rs
+++ b/crates/augurs-forecaster/src/transforms/error.rs
@@ -13,8 +13,8 @@ pub enum Error {
     /// The transform has not been fitted yet.
     #[error("transform has not been fitted yet")]
     NotFitted,
-    /// The input data is empty.
-    #[error("data must not be empty")]
+    /// The input data is empty, or contains only NaN values.
+    #[error("input data is empty, or contains only NaN values")]
     EmptyData,
     /// The input data contains non-positive values.
     #[error("data contains non-positive values")]

--- a/crates/augurs-forecaster/src/transforms/exp.rs
+++ b/crates/augurs-forecaster/src/transforms/exp.rs
@@ -109,6 +109,11 @@ mod test {
     }
 
     #[test]
+    fn test_logistic_nan() {
+        assert!(logistic(f64::NAN).is_nan());
+    }
+
+    #[test]
     fn test_logit() {
         let x = 0.5;
         let expected = 0.0;
@@ -122,6 +127,11 @@ mod test {
         let expected = (0.25_f64 / (1.0 - 0.25)).ln();
         let actual = logit(x);
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_logit_nan() {
+        assert!(logit(f64::NAN).is_nan());
     }
 
     #[test]

--- a/crates/augurs-forecaster/src/transforms/power.rs
+++ b/crates/augurs-forecaster/src/transforms/power.rs
@@ -197,6 +197,8 @@ impl Default for BoxCox {
 
 impl Transformer for BoxCox {
     fn fit(&mut self, data: &[f64]) -> Result<(), Error> {
+        // Avoid copying the data if we don't need to,
+        // i.e. if we're not ignoring NaNs or if there are no NaNs.
         if !self.ignore_nans || !data.iter().any(|&x| x.is_nan()) {
             self.lambda = optimize_box_cox_lambda(data)?;
         } else {
@@ -391,6 +393,8 @@ impl Default for YeoJohnson {
 
 impl Transformer for YeoJohnson {
     fn fit(&mut self, data: &[f64]) -> Result<(), Error> {
+        // Avoid copying the data if we don't need to,
+        // i.e. if we're not ignoring NaNs or if there are no NaNs.
         if !self.ignore_nans || !data.iter().any(|&x| x.is_nan()) {
             self.lambda = optimize_yeo_johnson_lambda(data)?;
         } else {

--- a/crates/augurs-forecaster/src/transforms/power.rs
+++ b/crates/augurs-forecaster/src/transforms/power.rs
@@ -183,7 +183,7 @@ impl BoxCox {
     /// lambda and simply passed through the transform.
     ///
     /// Defaults to `false`.
-    pub fn with_ignore_nans(mut self, ignore_nans: bool) -> Self {
+    pub fn ignore_nans(mut self, ignore_nans: bool) -> Self {
         self.ignore_nans = ignore_nans;
         self
     }
@@ -377,7 +377,7 @@ impl YeoJohnson {
     /// lambda and simply passed through the transform.
     ///
     /// Defaults to `false`.
-    pub fn with_ignore_nans(mut self, ignore_nans: bool) -> Self {
+    pub fn ignore_nans(mut self, ignore_nans: bool) -> Self {
         self.ignore_nans = ignore_nans;
         self
     }
@@ -524,7 +524,7 @@ mod test {
     #[test]
     fn box_cox_transform_ignore_nans() {
         let mut data = vec![1.0, 2.0, f64::NAN, 3.0];
-        let mut box_cox = BoxCox::new().with_ignore_nans(true);
+        let mut box_cox = BoxCox::new().ignore_nans(true);
         let expected = vec![0.0, 0.8284271247461903, f64::NAN, 1.4641016151377544];
         box_cox.fit_transform(&mut data).unwrap();
         assert_all_close(&expected, &data);
@@ -574,7 +574,7 @@ mod test {
     #[test]
     fn yeo_johnson_fit_transform_ignore_nans() {
         let mut data = vec![-1.0, 0.0, f64::NAN, 1.0];
-        let mut yeo_johnson = YeoJohnson::new().with_ignore_nans(true);
+        let mut yeo_johnson = YeoJohnson::new().ignore_nans(true);
         let expected = vec![-1.0000010312156777, 0.0, f64::NAN, 0.9999989687856643];
         yeo_johnson.fit_transform(&mut data).unwrap();
         assert_all_close(&expected, &data);


### PR DESCRIPTION
Similar to #227, but for power transforms.

Also add tests for ignoring NaNs in exponential transforms.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced error handling for NaN values in Box-Cox and Yeo-Johnson transformations.
	- Added option to ignore NaN values during data transformation.

- **Bug Fixes**
	- Improved error messages for empty or NaN-only input data.
	- Updated transformation functions to handle NaN inputs more gracefully.

- **Tests**
	- Added test cases for NaN handling in logistic and logit functions.
	- Expanded test coverage for transformation methods with NaN inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->