### PR TITLE
feat!: allow ignoring NaNs in JS transforms, too

### DIFF
--- a/crates/augurs-forecaster/src/transforms/error.rs
+++ b/crates/augurs-forecaster/src/transforms/error.rs
@@ -13,8 +13,8 @@ pub enum Error {
     /// The transform has not been fitted yet.
     #[error("transform has not been fitted yet")]
     NotFitted,
-    /// The input data is empty.
-    #[error("data must not be empty")]
+    /// The input data is empty, or contains only NaN values.
+    #[error("input data is empty, or contains only NaN values")]
     EmptyData,
     /// The input data contains non-positive values.
     #[error("data contains non-positive values")]

--- a/crates/augurs-forecaster/src/transforms/exp.rs
+++ b/crates/augurs-forecaster/src/transforms/exp.rs
@@ -109,6 +109,11 @@ mod test {
     }
 
     #[test]
+    fn test_logistic_nan() {
+        assert!(logistic(f64::NAN).is_nan());
+    }
+
+    #[test]
     fn test_logit() {
         let x = 0.5;
         let expected = 0.0;
@@ -122,6 +127,11 @@ mod test {
         let expected = (0.25_f64 / (1.0 - 0.25)).ln();
         let actual = logit(x);
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_logit_nan() {
+        assert!(logit(f64::NAN).is_nan());
     }
 
     #[test]

--- a/crates/augurs-forecaster/src/transforms/power.rs
+++ b/crates/augurs-forecaster/src/transforms/power.rs
@@ -197,6 +197,8 @@ impl Default for BoxCox {
 
 impl Transformer for BoxCox {
     fn fit(&mut self, data: &[f64]) -> Result<(), Error> {
+        // Avoid copying the data if we don't need to,
+        // i.e. if we're not ignoring NaNs or if there are no NaNs.
         if !self.ignore_nans || !data.iter().any(|&x| x.is_nan()) {
             self.lambda = optimize_box_cox_lambda(data)?;
         } else {
@@ -391,6 +393,8 @@ impl Default for YeoJohnson {
 
 impl Transformer for YeoJohnson {
     fn fit(&mut self, data: &[f64]) -> Result<(), Error> {
+        // Avoid copying the data if we don't need to,
+        // i.e. if we're not ignoring NaNs or if there are no NaNs.
         if !self.ignore_nans || !data.iter().any(|&x| x.is_nan()) {
             self.lambda = optimize_yeo_johnson_lambda(data)?;
         } else {

--- a/crates/augurs-forecaster/src/transforms/power.rs
+++ b/crates/augurs-forecaster/src/transforms/power.rs
@@ -183,7 +183,7 @@ impl BoxCox {
     /// lambda and simply passed through the transform.
     ///
     /// Defaults to `false`.
-    pub fn with_ignore_nans(mut self, ignore_nans: bool) -> Self {
+    pub fn ignore_nans(mut self, ignore_nans: bool) -> Self {
         self.ignore_nans = ignore_nans;
         self
     }
@@ -377,7 +377,7 @@ impl YeoJohnson {
     /// lambda and simply passed through the transform.
     ///
     /// Defaults to `false`.
-    pub fn with_ignore_nans(mut self, ignore_nans: bool) -> Self {
+    pub fn ignore_nans(mut self, ignore_nans: bool) -> Self {
         self.ignore_nans = ignore_nans;
         self
     }
@@ -524,7 +524,7 @@ mod test {
     #[test]
     fn box_cox_transform_ignore_nans() {
         let mut data = vec![1.0, 2.0, f64::NAN, 3.0];
-        let mut box_cox = BoxCox::new().with_ignore_nans(true);
+        let mut box_cox = BoxCox::new().ignore_nans(true);
         let expected = vec![0.0, 0.8284271247461903, f64::NAN, 1.4641016151377544];
         box_cox.fit_transform(&mut data).unwrap();
         assert_all_close(&expected, &data);
@@ -574,7 +574,7 @@ mod test {
     #[test]
     fn yeo_johnson_fit_transform_ignore_nans() {
         let mut data = vec![-1.0, 0.0, f64::NAN, 1.0];
-        let mut yeo_johnson = YeoJohnson::new().with_ignore_nans(true);
+        let mut yeo_johnson = YeoJohnson::new().ignore_nans(true);
         let expected = vec![-1.0000010312156777, 0.0, f64::NAN, 0.9999989687856643];
         yeo_johnson.fit_transform(&mut data).unwrap();
         assert_all_close(&expected, &data);

--- a/js/augurs-transforms-js/src/lib.rs
+++ b/js/augurs-transforms-js/src/lib.rs
@@ -11,20 +11,32 @@ use augurs_forecaster::transforms::{StandardScaler, Transformer, YeoJohnson};
 ///
 /// @experimental
 #[derive(Debug, Deserialize, Tsify)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "camelCase", tag = "type")]
 #[tsify(from_wasm_abi)]
 pub enum Transform {
     /// Standardize the data such that it has zero mean and unit variance.
-    StandardScaler,
+    StandardScaler {
+        /// Whether to ignore NaNs.
+        #[serde(default, rename = "ignoreNaNs")]
+        ignore_nans: bool,
+    },
     /// The Yeo-Johnson transform.
-    YeoJohnson,
+    YeoJohnson {
+        /// Whether to ignore NaNs.
+        #[serde(default, rename = "ignoreNaNs")]
+        ignore_nans: bool,
+    },
 }
 
 impl Transform {
     fn into_transformer(self) -> Box<dyn Transformer> {
         match self {
-            Transform::StandardScaler => Box::new(StandardScaler::new()),
-            Transform::YeoJohnson => Box::new(YeoJohnson::new()),
+            Transform::StandardScaler { ignore_nans } => {
+                Box::new(StandardScaler::new().ignore_nans(ignore_nans))
+            }
+            Transform::YeoJohnson { ignore_nans } => {
+                Box::new(YeoJohnson::new().ignore_nans(ignore_nans))
+            }
         }
     }
 }

--- a/js/testpkg/transforms.test.ts
+++ b/js/testpkg/transforms.test.ts
@@ -40,14 +40,12 @@ describe('transforms', () => {
     }
   });
 
-
   describe('pipeline', () => {
     it('works with arrays', () => {
-      const pt = new Pipeline(["standardScaler", "yeoJohnson"]);
+      const pt = new Pipeline([{ type: "standardScaler" }, { type: "yeoJohnson" }]);
       const transformed = pt.fitTransform(y);
       expect(transformed).toBeInstanceOf(Float64Array);
       expect(transformed).toHaveLength(y.length);
-      console.log(transformed);
       const inverse = pt.inverseTransform(transformed);
       expect(inverse).toBeInstanceOf(Float64Array);
       expect(inverse).toHaveLength(y.length);
@@ -58,6 +56,34 @@ describe('transforms', () => {
     it('handles empty pipeline', () => {
       const pt = new Pipeline([]);
       expect(() => pt.fitTransform(y)).not.toThrow();
+    });
+
+    it('handles invalid transforms', () => {
+      // @ts-ignore
+      expect(() => new Pipeline(["invalidTransform"])).toThrow();
+    });
+  });
+
+  describe('pipeline with nans', () => {
+    const yWithNaNs = [...y];
+    yWithNaNs[10] = NaN;
+    yWithNaNs[20] = NaN;
+
+    it('works with arrays', () => {
+      const pt = new Pipeline([{ type: "standardScaler", ignoreNaNs: true }, { type: "yeoJohnson", ignoreNaNs: true }]);
+      const transformed = pt.fitTransform(yWithNaNs);
+      expect(transformed).toBeInstanceOf(Float64Array);
+      expect(transformed).toHaveLength(yWithNaNs.length);
+      const inverse = pt.inverseTransform(transformed);
+      expect(inverse).toBeInstanceOf(Float64Array);
+      expect(inverse).toHaveLength(yWithNaNs.length);
+      //@ts-ignore
+      expect(Array.from(inverse)).toAllBeCloseTo(yWithNaNs);
+    });
+
+    it('handles empty pipeline', () => {
+      const pt = new Pipeline([]);
+      expect(() => pt.fitTransform(yWithNaNs)).not.toThrow();
     });
 
     it('handles invalid transforms', () => {


### PR DESCRIPTION
Unfortunately this requires a breaking change to the JS API;
while transforms were previously specified as an array of strings,
they are now specified as an array of objects with a `type` property.

This is a breaking change, but it's a sensible one, because it will
allow us to add further options to transforms in future.

BREAKING CHANGE: transforms are now specified as an array of objects
with a `type` property.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for handling NaN values in data transformations
	- Introduced option to ignore NaN values during `StandardScaler` and `YeoJohnson` transformations

- **Tests**
	- Added test cases for pipelines with NaN values
	- Expanded test coverage for transformation scenarios involving missing data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->