### PR TITLE
tests: run benchmarks in separate CI check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,6 +45,27 @@ jobs:
       - name: Run doc tests
         run: just doctest
 
+  bench:
+    name: Run benchmarks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: moonrepo/setup-rust@v1
+        with:
+          bins: cargo-nextest,just
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # Download the Prophet Stan model since an example requires it.
+      - name: Download Prophet Stan model
+        run: just download-prophet-stan-model
+
+      - name: Run benchmarks in test mode
+        run: just test-bench
+
   test-book:
     name: Test Book
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -59,10 +59,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Download the Prophet Stan model since an example requires it.
-      - name: Download Prophet Stan model
-        run: just download-prophet-stan-model
-
       - name: Run benchmarks in test mode
         run: just test-bench
 

--- a/justfile
+++ b/justfile
@@ -19,11 +19,22 @@ test:
     --exclude *-js \
     --exclude pyaugurs
 
-# Run all unit and integration tests, plus examples and benchmarks, except for those which require `iai` (which isn't available on all platforms) and the Prophet benchmarks which require a STAN installation.
+# Run all unit and integration tests, plus examples, except for those which require `iai` (which isn't available on all platforms) and the Prophet benchmarks which require a STAN installation.
 test-all:
   cargo nextest run \
     --all-features \
     --all-targets \
+    --workspace \
+    --exclude *-js \
+    --exclude pyaugurs \
+    -E 'not (binary(/iai/) | binary(/prophet-cmdstan/) | kind(bench))'
+
+# Run benchmarks in "test mode" (but with optimizations) using nextest.
+test-bench:
+  cargo nextest run \
+    --release \
+    --all-features \
+    --benches \
     --workspace \
     --exclude *-js \
     --exclude pyaugurs \


### PR DESCRIPTION
Benchmarks often cause CI to take an additional 2-3 minutes to run,
so let's run them separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added a new benchmarking job to the GitHub Actions workflow.
	- Introduced a dedicated command for running benchmarks in the project's task runner.

- **Chores**
	- Updated workflow configuration to support benchmark testing.
	- Refined task runner configuration for more precise benchmark execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->