### PR TITLE
chore: configure release-plz to use a single changelog for all crates

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,21 @@
+[workspace]
+# Set the path of all the crates to the changelog to the root of the repository
+# so we get a single changelog with all changes.
+# See https://release-plz.ieni.dev/docs/extra/single-changelog#all-packages.
+changelog_path = "./CHANGELOG.md"
+
+[changelog]
+body = """
+
+## `{{ package }}` - [{{ version | trim_start_matches(pat="v") }}]{%- if release_link -%}({{ release_link }}){% endif %} - {{ timestamp | date(format="%Y-%m-%d") }}
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}
+{%- if commit.scope -%}
+- *({{commit.scope}})* {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}{%- if commit.links %} ({% for link in commit.links %}[{{link.text}}]({{link.href}}) {% endfor -%}){% endif %}
+{% else -%}
+- {% if commit.breaking %}[**breaking**] {% endif %}{{ commit.message }}
+{% endif -%}
+{% endfor -%}
+{% endfor -%}
+"""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
	- Updated release configuration to centralize changelog management
	- Improved changelog generation with new template for tracking package changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->