### PR TITLE
chore: update dependabot config to group Rust deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      rust-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     # Check for updates every Monday


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Enhanced dependency management configuration for Rust projects
	- Configured Dependabot to group Rust dependency updates across major, minor, and patch versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->