### PR TITLE
improve(detector): remove &self from OutlierDetector::preprocess

### DIFF
--- a/crates/augurs-outlier/src/dbscan.rs
+++ b/crates/augurs-outlier/src/dbscan.rs
@@ -52,7 +52,7 @@ pub struct DbscanDetector {
 
 impl OutlierDetector for DbscanDetector {
     type PreprocessedData = Data;
-    fn preprocess(&self, y: &[&[f64]]) -> Result<Self::PreprocessedData, Error> {
+    fn preprocess(y: &[&[f64]]) -> Result<Self::PreprocessedData, Error> {
         Ok(Data::from_row_major(y))
     }
 
@@ -558,7 +558,7 @@ mod tests {
         ];
         let detector =
             DbscanDetector::with_sensitivity(0.5).expect("sensitivity is between 0.0 and 1.0");
-        let processed = detector.preprocess(data).unwrap();
+        let processed = DbscanDetector::preprocess(data).unwrap();
         let outliers = detector.detect(&processed).unwrap();
 
         assert_eq!(outliers.outlying_series.len(), 1);
@@ -594,7 +594,7 @@ mod tests {
     #[test]
     fn test_realistic() {
         let dbscan = DbscanDetector::with_sensitivity(0.8).unwrap();
-        let data = dbscan.preprocess(crate::testing::SERIES).unwrap();
+        let data = DbscanDetector::preprocess(crate::testing::SERIES).unwrap();
         let results = dbscan.detect(&data).unwrap();
         assert!(!results.outlying_series.contains(&0));
         assert!(!results.outlying_series.contains(&1));
@@ -630,7 +630,7 @@ mod tests {
             &[1.5, 2.1, 6.4, 8.5],
         ];
         let dbscan = DbscanDetector::with_epsilon(1.0);
-        let processed = dbscan.preprocess(data).unwrap();
+        let processed = DbscanDetector::preprocess(data).unwrap();
         // Should not panic.
         let results = dbscan.detect(&processed).unwrap();
 
@@ -648,7 +648,7 @@ mod tests {
             &[7.0, 8.0, 9.0, 10.0],
         ];
         let dbscan = DbscanDetector::with_epsilon(1.0);
-        let processed = dbscan.preprocess(data).unwrap();
+        let processed = DbscanDetector::preprocess(data).unwrap();
         let results = dbscan.detect(&processed).unwrap();
         assert!(results.cluster_band.is_none());
     }
@@ -657,7 +657,7 @@ mod tests {
     fn test_no_cluster_band_two_series() {
         let data: &[&[f64]] = &[&[1.0, 2.0, 3.0, 4.0], &[4.0, 5.0, 6.0, 7.0]];
         let dbscan = DbscanDetector::with_epsilon(4.0);
-        let processed = dbscan.preprocess(data).unwrap();
+        let processed = DbscanDetector::preprocess(data).unwrap();
         let results = dbscan.detect(&processed).unwrap();
         assert!(results.cluster_band.is_none());
     }

--- a/crates/augurs-outlier/src/lib.rs
+++ b/crates/augurs-outlier/src/lib.rs
@@ -223,7 +223,7 @@ pub trait OutlierDetector {
     /// change. For example, if the input data is the same but the sensitivity
     /// changes, the outlier detection calculation can be rerun without
     /// reprocessing the input data.
-    fn preprocess(&self, y: &[&[f64]]) -> Result<Self::PreprocessedData, Error>;
+    fn preprocess(y: &[&[f64]]) -> Result<Self::PreprocessedData, Error>;
 
     /// Detect outliers in the given slice of series.
     ///
@@ -243,7 +243,7 @@ mod test {
     impl OutlierDetector for DummyDetector {
         type PreprocessedData = Vec<Vec<f64>>;
 
-        fn preprocess(&self, y: &[&[f64]]) -> Result<Self::PreprocessedData, Error> {
+        fn preprocess(y: &[&[f64]]) -> Result<Self::PreprocessedData, Error> {
             Ok(y.iter().map(|x| x.to_vec()).collect())
         }
 

--- a/crates/augurs/tests/integration.rs
+++ b/crates/augurs/tests/integration.rs
@@ -1,5 +1,7 @@
 //! Integration tests for the augurs wrapper crate.
 
+use augurs_outlier::{DbscanDetector, MADDetector};
+
 #[cfg(feature = "changepoint")]
 #[test]
 fn test_changepoint() {
@@ -209,7 +211,7 @@ fn test_outlier_dbscan() {
     ];
     let detector =
         DbscanDetector::with_sensitivity(0.5).expect("sensitivity is between 0.0 and 1.0");
-    let processed = detector.preprocess(data).unwrap();
+    let processed = DbscanDetector::preprocess(data).unwrap();
     let outliers = detector.detect(&processed).unwrap();
 
     assert_eq!(outliers.outlying_series.len(), 1);
@@ -229,7 +231,7 @@ fn test_outlier_mad() {
         &[1.5, 2.1, 6.4, 8.5],
     ];
     let detector = MADDetector::with_sensitivity(0.5).unwrap();
-    let processed = detector.preprocess(data).unwrap();
+    let processed = MADDetector::preprocess(data).unwrap();
     let outliers = detector.detect(&processed).unwrap();
 
     assert_eq!(outliers.outlying_series.len(), 1);

--- a/examples/outlier-detection/examples/dbscan_outlier_detection.rs
+++ b/examples/outlier-detection/examples/dbscan_outlier_detection.rs
@@ -34,7 +34,7 @@ fn main() {
 
     // Preprocess the data using the detector.
     // This function will return an error if the input data is invalid.
-    let processed = detector.preprocess(SERIES).expect("input data is valid");
+    let processed = DbscanDetector::preprocess(SERIES).expect("input data is valid");
 
     // Note: we could also have created the preprocessed data from 'column major' data,
     // using `DbscanData::from_column_major`.

--- a/examples/outlier-detection/examples/mad_outlier_detection.rs
+++ b/examples/outlier-detection/examples/mad_outlier_detection.rs
@@ -30,7 +30,7 @@ fn main() {
 
     // Preprocess the data using the detector.
     // This function will return an error if the input data is invalid.
-    let processed = detector.preprocess(SERIES).expect("input data is valid");
+    let processed = MADDetector::preprocess(SERIES).expect("input data is valid");
 
     // Detect outliers in the preprocessed data.
     // This function will return an error if the detection fails; this may be impossible

--- a/js/augurs-outlier-js/src/lib.rs
+++ b/js/augurs-outlier-js/src/lib.rs
@@ -27,14 +27,14 @@ impl Detector {
         let series: Vec<_> = series.iter().map(|x| x.as_slice()).collect();
         match self {
             Self::Dbscan(detector) => {
-                let data = detector.preprocess(&series)?;
+                let data = augurs_outlier::DbscanDetector::preprocess(&series)?;
                 Ok(LoadedDetector::Dbscan {
                     detector: detector.clone(),
                     data,
                 })
             }
             Self::Mad(detector) => {
-                let data = detector.preprocess(&series)?;
+                let data = augurs_outlier::MADDetector::preprocess(&series)?;
                 Ok(LoadedDetector::Mad {
                     detector: detector.clone(),
                     data,
@@ -48,11 +48,11 @@ impl Detector {
         let series: Vec<_> = series.iter().map(|x| x.as_slice()).collect();
         match self {
             Self::Dbscan(detector) => {
-                let data = detector.preprocess(&series)?;
+                let data = augurs_outlier::DbscanDetector::preprocess(&series)?;
                 Ok(detector.detect(&data)?.into())
             }
             Self::Mad(detector) => {
-                let data = detector.preprocess(&series)?;
+                let data = augurs_outlier::MADDetector::preprocess(&series)?;
                 Ok(detector.detect(&data)?.into())
             }
         }


### PR DESCRIPTION
Fix #242 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Updated outlier detection processing to use static (class-level) methods, eliminating the need for instance-based calls.
	- Streamlined preprocessing and data analysis routines for improved clarity and usability.
- **Tests**
	- Updated test cases to reflect the new static method invocation approach for `DbscanDetector` and `MADDetector`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->