### PR TITLE
Add JS bindings for Prophet regressors

### DIFF
--- a/js/augurs-prophet-js/src/lib.rs
+++ b/js/augurs-prophet-js/src/lib.rs
@@ -180,8 +180,13 @@ impl Prophet {
     /// Add a regressor to the model. Name should be one of the column names.
     /// The extra regressor must be known for both the history and for future dates.
     #[wasm_bindgen(js_name = "addRegressor")]
-    pub fn add_regressor(&mut self, name: String, regressor: Regressor) -> Result<(), JsError> {
-        self.inner.add_regressor(name, regressor.into());
+    pub fn add_regressor(
+        &mut self,
+        name: String,
+        regressor: Option<Regressor>,
+    ) -> Result<(), JsError> {
+        self.inner
+            .add_regressor(name, regressor.unwrap_or_default().into());
         Ok(())
     }
 }
@@ -246,9 +251,18 @@ pub struct Regressor {
     #[serde(default)]
     mode: FeatureMode,
 
+    /// The prior scale of this regressor.
+    ///
+    /// Defaults to the `seasonality_prior_scale` of the Prophet model
+    /// the regressor is added to.
     #[tsify(optional, type = "number")]
     prior_scale: Option<PositiveFloat>,
 
+    /// Whether to standardize this regressor.
+    ///
+    /// The default is to use automatic standardization, which will standardize
+    /// numeric regressors and leave binary regressors alone.
+    #[serde(default)]
     standardize: Standardize,
 }
 

--- a/js/augurs-prophet-js/src/lib.rs
+++ b/js/augurs-prophet-js/src/lib.rs
@@ -240,6 +240,10 @@ impl From<Seasonality> for augurs_prophet::Seasonality {
 #[serde(rename_all = "camelCase")]
 #[tsify(from_wasm_abi, into_wasm_abi, type_prefix = "Prophet")]
 pub struct Regressor {
+    /// The mode of this regressor.
+    ///
+    /// Defaults to "additive".
+    #[serde(default)]
     mode: FeatureMode,
 
     #[tsify(optional, type = "number")]

--- a/js/testpkg/prophet.test.ts
+++ b/js/testpkg/prophet.test.ts
@@ -84,5 +84,16 @@ describe('Prophet', () => {
       const prophet = new Prophet({optimizer});
       prophet.addRegressor('feature1', reg);
     });
+
+    it('can be set with just name', () => {
+      const prophet = new Prophet({optimizer});
+      prophet.addRegressor('feature1');
+    });
+
+    it('can be set with name using mode', () => {
+      const reg: ProphetRegressor = {mode: "multiplicative"};
+      const prophet = new Prophet({optimizer});
+      prophet.addRegressor('feature1', reg);
+    });
   });
 });

--- a/js/testpkg/prophet.test.ts
+++ b/js/testpkg/prophet.test.ts
@@ -4,6 +4,7 @@ import {
   Prophet,
   ProphetHoliday,
   ProphetHolidayOccurrence,
+  ProphetRegressor,
   ProphetSeasonality,
   ProphetSeasonalityOption,
   initSync
@@ -74,6 +75,14 @@ describe('Prophet', () => {
         const prophet = new Prophet({ optimizer, dailySeasonality });
         const seasonality: ProphetSeasonality = { period: 30.5, fourierOrder: 5 };
         prophet.addSeasonality('daily', seasonality);
+    });
+  });
+
+  describe('regressors', () => {
+    it('can be set', () => {
+      const reg: ProphetRegressor = {mode: "additive", priorScale: 0.5, standardize: "auto"};
+      const prophet = new Prophet({optimizer});
+      prophet.addRegressor('feature1', reg);
     });
   });
 });


### PR DESCRIPTION
Related to #167 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a method to add regressors to the forecasting model with customizable settings, including standardization options.

- **Tests**
  - Added a new test suite to verify the functionality of adding regressors in the `Prophet` model, ensuring proper handling of new features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->