### PR TITLE
Add JS bindings for Prophet make_future_dataframe

### DIFF
--- a/crates/augurs-prophet/src/data.rs
+++ b/crates/augurs-prophet/src/data.rs
@@ -235,12 +235,37 @@ impl TrainingData {
 /// regressors, you must include them in the prediction data.
 #[derive(Clone, Debug)]
 pub struct PredictionData {
-    pub(crate) n: usize,
-    pub(crate) ds: Vec<TimestampSeconds>,
-    pub(crate) cap: Option<Vec<f64>>,
-    pub(crate) floor: Option<Vec<f64>>,
-    pub(crate) seasonality_conditions: HashMap<String, Vec<bool>>,
-    pub(crate) x: HashMap<String, Vec<f64>>,
+    /// The number of time points in the prediction data.
+    pub n: usize,
+
+    /// The timestamps of the time series.
+    ///
+    /// These should be in seconds since the epoch.
+    pub ds: Vec<TimestampSeconds>,
+
+    /// Optionally, an upper bound (cap) on the values of the time series.
+    ///
+    /// Only used if the model's growth type is `logistic`.
+    pub cap: Option<Vec<f64>>,
+
+    /// Optionally, a lower bound (floor) on the values of the time series.
+    ///
+    /// Only used if the model's growth type is `logistic`.
+    pub floor: Option<Vec<f64>>,
+
+    /// Indicator variables for conditional seasonalities.
+    ///
+    /// The keys of the map are the names of the seasonality components,
+    /// and the values are boolean arrays of length `n` where `true` indicates
+    /// that the component is active for the corresponding time point.
+    pub seasonality_conditions: HashMap<String, Vec<bool>>,
+
+    /// Exogenous regressors.
+    ///
+    /// The keys of the map are the names of the regressors,
+    /// and the values are arrays of length `n` containing the regressor values
+    /// for each time point.
+    pub x: HashMap<String, Vec<f64>>,
 }
 
 impl PredictionData {

--- a/js/augurs-prophet-js/src/lib.rs
+++ b/js/augurs-prophet-js/src/lib.rs
@@ -1042,8 +1042,14 @@ impl From<(Option<f64>, augurs_prophet::Predictions)> for Predictions {
 #[tsify(from_wasm_abi, type_prefix = "Prophet")]
 pub struct MakeFutureDataframeOptions {
     /// Whether to include the historical dates in the future dataframe.
-    #[serde(default)]
+    #[serde(default = "MakeFutureDataframeOptions::default_include_history")]
     include_history: bool,
+}
+
+impl MakeFutureDataframeOptions {
+    fn default_include_history() -> bool {
+        true
+    }
 }
 
 impl Default for MakeFutureDataframeOptions {

--- a/js/augurs-prophet-js/src/lib.rs
+++ b/js/augurs-prophet-js/src/lib.rs
@@ -1036,7 +1036,7 @@ impl From<(Option<f64>, augurs_prophet::Predictions)> for Predictions {
     }
 }
 
-/// Options to specify whether to include the historical dates in the future dataframe for predictions.
+/// Options for `makeFutureDataframe`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Tsify)]
 #[serde(rename_all = "camelCase")]
 #[tsify(from_wasm_abi, type_prefix = "Prophet")]

--- a/js/augurs-prophet-js/src/lib.rs
+++ b/js/augurs-prophet-js/src/lib.rs
@@ -190,6 +190,8 @@ impl Prophet {
         Ok(())
     }
 
+    /// Create dates to use for predictions.
+    /// Returns an error if the model has not been fit.
     #[wasm_bindgen(js_name = "makeFutureDataFrame")]
     pub fn make_future_dataframe(
         &self,

--- a/js/augurs-prophet-js/src/lib.rs
+++ b/js/augurs-prophet-js/src/lib.rs
@@ -192,7 +192,7 @@ impl Prophet {
 
     /// Create dates to use for predictions.
     /// Returns an error if the model has not been fit.
-    #[wasm_bindgen(js_name = "makeFutureDataFrame")]
+    #[wasm_bindgen(js_name = "makeFutureDataframe")]
     pub fn make_future_dataframe(
         &self,
         horizon: u32,

--- a/js/augurs-prophet-js/src/lib.rs
+++ b/js/augurs-prophet-js/src/lib.rs
@@ -196,7 +196,7 @@ impl Prophet {
     pub fn make_future_dataframe(
         &self,
         horizon: u32,
-        include_history: Option<IncludeHistory>,
+        include_history: Option<IncludeHistoryOptions>,
     ) -> Result<PredictionData, JsError> {
         let horizon = NonZeroU32::new(horizon).ok_or(JsError::new("Horizon must be greater than 0"))?;
 
@@ -1036,32 +1036,38 @@ impl From<(Option<f64>, augurs_prophet::Predictions)> for Predictions {
     }
 }
 
-/// Whether to include the historical dates in the future dataframe for predictions.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Default, Deserialize, Tsify)]
+/// Options to specify whether to include the historical dates in the future dataframe for predictions.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Tsify)]
 #[serde(rename_all = "camelCase")]
 #[tsify(from_wasm_abi, type_prefix = "Prophet")]
-pub enum IncludeHistory {
-    /// Include the historical dates in the future dataframe.
-    #[default]
-    Yes,
-    /// Do not include the historical dates in the future data frame.
-    No,
+pub struct IncludeHistoryOptions {
+    /// Whether to include the historical dates in the future dataframe.
+    include_history: bool,
 }
 
-impl From<IncludeHistory> for augurs_prophet::IncludeHistory {
-    fn from(value: IncludeHistory) -> Self {
-        match value {
-            IncludeHistory::Yes => Self::Yes,
-            IncludeHistory::No => Self::No,
+impl Default for IncludeHistoryOptions {
+    fn default() -> Self {
+        Self {
+            include_history: true,
         }
     }
 }
 
-impl From<augurs_prophet::IncludeHistory> for IncludeHistory {
+impl From<IncludeHistoryOptions> for augurs_prophet::IncludeHistory {
+    fn from(value: IncludeHistoryOptions) -> Self {
+        if value.include_history {
+            Self::Yes
+        } else {
+            Self::No
+        }
+    }
+}
+
+impl From<augurs_prophet::IncludeHistory> for IncludeHistoryOptions {
     fn from(value: augurs_prophet::IncludeHistory) -> Self {
         match value {
-            augurs_prophet::IncludeHistory::Yes => Self::Yes,
-            augurs_prophet::IncludeHistory::No => Self::No,
+            augurs_prophet::IncludeHistory::Yes => Self { include_history: true },
+            augurs_prophet::IncludeHistory::No => Self { include_history: false },
         }
     }
 }

--- a/js/augurs-prophet-js/src/lib.rs
+++ b/js/augurs-prophet-js/src/lib.rs
@@ -196,11 +196,11 @@ impl Prophet {
     pub fn make_future_dataframe(
         &self,
         horizon: u32,
-        include_history: Option<IncludeHistoryOptions>,
+        opts: Option<MakeFutureDataframeOptions>,
     ) -> Result<PredictionData, JsError> {
         let horizon = NonZeroU32::new(horizon).ok_or(JsError::new("Horizon must be greater than 0"))?;
 
-        let future_dataframe = self.inner.make_future_dataframe(horizon, include_history.unwrap_or_default().into())?;
+        let future_dataframe = self.inner.make_future_dataframe(horizon, opts.unwrap_or_default().into())?;
         Ok(future_dataframe.into())
     }
 }
@@ -1040,12 +1040,13 @@ impl From<(Option<f64>, augurs_prophet::Predictions)> for Predictions {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Tsify)]
 #[serde(rename_all = "camelCase")]
 #[tsify(from_wasm_abi, type_prefix = "Prophet")]
-pub struct IncludeHistoryOptions {
+pub struct MakeFutureDataframeOptions {
     /// Whether to include the historical dates in the future dataframe.
+    #[serde(default)]
     include_history: bool,
 }
 
-impl Default for IncludeHistoryOptions {
+impl Default for MakeFutureDataframeOptions {
     fn default() -> Self {
         Self {
             include_history: true,
@@ -1053,8 +1054,8 @@ impl Default for IncludeHistoryOptions {
     }
 }
 
-impl From<IncludeHistoryOptions> for augurs_prophet::IncludeHistory {
-    fn from(value: IncludeHistoryOptions) -> Self {
+impl From<MakeFutureDataframeOptions> for augurs_prophet::IncludeHistory {
+    fn from(value: MakeFutureDataframeOptions) -> Self {
         if value.include_history {
             Self::Yes
         } else {
@@ -1063,7 +1064,7 @@ impl From<IncludeHistoryOptions> for augurs_prophet::IncludeHistory {
     }
 }
 
-impl From<augurs_prophet::IncludeHistory> for IncludeHistoryOptions {
+impl From<augurs_prophet::IncludeHistory> for MakeFutureDataframeOptions {
     fn from(value: augurs_prophet::IncludeHistory) -> Self {
         match value {
             augurs_prophet::IncludeHistory::Yes => Self { include_history: true },

--- a/js/augurs-prophet-js/src/lib.rs
+++ b/js/augurs-prophet-js/src/lib.rs
@@ -198,9 +198,12 @@ impl Prophet {
         horizon: u32,
         opts: Option<MakeFutureDataframeOptions>,
     ) -> Result<PredictionData, JsError> {
-        let horizon = NonZeroU32::new(horizon).ok_or(JsError::new("Horizon must be greater than 0"))?;
+        let horizon =
+            NonZeroU32::new(horizon).ok_or(JsError::new("Horizon must be greater than 0"))?;
 
-        let future_dataframe = self.inner.make_future_dataframe(horizon, opts.unwrap_or_default().into())?;
+        let future_dataframe = self
+            .inner
+            .make_future_dataframe(horizon, opts.unwrap_or_default().into())?;
         Ok(future_dataframe.into())
     }
 }
@@ -1038,18 +1041,12 @@ impl From<(Option<f64>, augurs_prophet::Predictions)> for Predictions {
 
 /// Options for `makeFutureDataframe`.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Deserialize, Tsify)]
+#[serde(default)]
 #[serde(rename_all = "camelCase")]
 #[tsify(from_wasm_abi, type_prefix = "Prophet")]
 pub struct MakeFutureDataframeOptions {
     /// Whether to include the historical dates in the future dataframe.
-    #[serde(default = "MakeFutureDataframeOptions::default_include_history")]
     include_history: bool,
-}
-
-impl MakeFutureDataframeOptions {
-    fn default_include_history() -> bool {
-        true
-    }
 }
 
 impl Default for MakeFutureDataframeOptions {
@@ -1073,8 +1070,12 @@ impl From<MakeFutureDataframeOptions> for augurs_prophet::IncludeHistory {
 impl From<augurs_prophet::IncludeHistory> for MakeFutureDataframeOptions {
     fn from(value: augurs_prophet::IncludeHistory) -> Self {
         match value {
-            augurs_prophet::IncludeHistory::Yes => Self { include_history: true },
-            augurs_prophet::IncludeHistory::No => Self { include_history: false },
+            augurs_prophet::IncludeHistory::Yes => Self {
+                include_history: true,
+            },
+            augurs_prophet::IncludeHistory::No => Self {
+                include_history: false,
+            },
         }
     }
 }

--- a/js/testpkg/prophet.test.ts
+++ b/js/testpkg/prophet.test.ts
@@ -1,5 +1,4 @@
 import { readFileSync } from "node:fs";
-
 import {
   Prophet,
   ProphetHoliday,
@@ -10,16 +9,16 @@ import {
   initSync
 } from '@bsull/augurs/prophet';
 import { optimizer } from '@bsull/augurs-prophet-wasmstan';
-
 import { describe, expect, it } from 'vitest';
 
 initSync({ module: readFileSync('node_modules/@bsull/augurs/prophet_bg.wasm') });
 
-const ds = [1704067200, 1704871384, 1705675569, 1706479753, 1707283938, 1708088123,
-  1708892307, 1709696492, 1710500676, 1711304861, 1712109046, 1712913230,
-];
-const y = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0];
-const cap = Array(y.length).fill(12.0);
+const START_TIMESTAMP = 1704067200;
+const NINE_DAYS = 9 * 86400;
+const TOTAL_LENGTH = 24;
+const ds = Array.from({ length: TOTAL_LENGTH }, (_, i) => START_TIMESTAMP + (i * NINE_DAYS));
+const y = Array.from({ length: TOTAL_LENGTH }, (_, i) => i + 1); // [1, 2, ..., 24]
+const cap = Array(y.length).fill(24.0);
 const floor = Array(y.length).fill(0.0);
 
 describe('Prophet', () => {
@@ -30,7 +29,7 @@ describe('Prophet', () => {
 
   it('can be fit with arrays', () => {
     const prophet = new Prophet({ optimizer });
-    prophet.fit({ ds, y })
+    prophet.fit({ ds, y });
     const preds = prophet.predict();
     expect(preds.yhat.point).toHaveLength(y.length);
   });
@@ -51,7 +50,7 @@ describe('Prophet', () => {
 
   it('returns regular arrays', () => {
     const prophet = new Prophet({ optimizer });
-    prophet.fit({ ds, y })
+    prophet.fit({ ds, y });
     const preds = prophet.predict();
     expect(preds.yhat.point).toHaveLength(y.length);
     expect(preds.yhat.point).toBeInstanceOf(Array);
@@ -61,39 +60,66 @@ describe('Prophet', () => {
     it('can be set', () => {
       const occurrences: ProphetHolidayOccurrence[] = [
         { start: new Date('2024-12-25').getTime() / 1000, end: new Date('2024-12-26').getTime() / 1000 },
-      ]
+      ];
       const holidays: Map<string, ProphetHoliday> = new Map([
         ["Christmas", { occurrences }],
       ]);
       new Prophet({ optimizer, holidays });
     });
-  })
+  });
 
   describe('seasonality', () => {
     it('can be set', () => {
-        const dailySeasonality: ProphetSeasonalityOption = { type: "manual", enabled: false };
-        const prophet = new Prophet({ optimizer, dailySeasonality });
-        const seasonality: ProphetSeasonality = { period: 30.5, fourierOrder: 5 };
-        prophet.addSeasonality('daily', seasonality);
+      const dailySeasonality: ProphetSeasonalityOption = { type: "manual", enabled: false };
+      const prophet = new Prophet({ optimizer, dailySeasonality });
+      const seasonality: ProphetSeasonality = { period: 30.5, fourierOrder: 5 };
+      prophet.addSeasonality('daily', seasonality);
     });
   });
 
   describe('regressors', () => {
     it('can be set', () => {
-      const reg: ProphetRegressor = {mode: "additive", priorScale: 0.5, standardize: "auto"};
-      const prophet = new Prophet({optimizer});
+      const reg: ProphetRegressor = { mode: "additive", priorScale: 0.5, standardize: "auto" };
+      const prophet = new Prophet({ optimizer });
       prophet.addRegressor('feature1', reg);
     });
 
     it('can be set with just name', () => {
-      const prophet = new Prophet({optimizer});
+      const prophet = new Prophet({ optimizer });
       prophet.addRegressor('feature1');
     });
 
     it('can be set with name using mode', () => {
-      const reg: ProphetRegressor = {mode: "multiplicative"};
-      const prophet = new Prophet({optimizer});
+      const reg: ProphetRegressor = { mode: "multiplicative" };
+      const prophet = new Prophet({ optimizer });
       prophet.addRegressor('feature1', reg);
+    });
+  });
+
+  describe('makeFutureDataframe', () => {
+    it('can be called with horizon without history', () => {
+      const prophet = new Prophet({ optimizer });
+      prophet.fit({ ds, y });
+
+      const future = prophet.makeFutureDataFrame(10, 'no');
+      expect(future.ds).toHaveLength(10);
+
+      const fullSeries = [...ds, ...future.ds];
+      for (let i = 1; i < fullSeries.length; i++) {
+        expect(fullSeries[i] - fullSeries[i - 1]).toBe(NINE_DAYS);
+      }
+    });
+
+    it('can be called with horizon with history as default option', () => {
+      const prophet = new Prophet({ optimizer });
+      prophet.fit({ ds, y });
+
+      const future = prophet.makeFutureDataFrame(10);
+      expect(future.ds).toHaveLength(10 + TOTAL_LENGTH);
+
+      for (let i = 1; i < future.ds.length; i++) {
+        expect(future.ds[i] - future.ds[i - 1]).toBe(NINE_DAYS);
+      }
     });
   });
 });

--- a/js/testpkg/prophet.test.ts
+++ b/js/testpkg/prophet.test.ts
@@ -101,7 +101,7 @@ describe('Prophet', () => {
       const prophet = new Prophet({ optimizer });
       prophet.fit({ ds, y });
 
-      const future = prophet.makeFutureDataFrame(10, 'no');
+      const future = prophet.makeFutureDataframe(10, {includeHistory: false});
       expect(future.ds).toHaveLength(10);
 
       const fullSeries = [...ds, ...future.ds];
@@ -114,7 +114,7 @@ describe('Prophet', () => {
       const prophet = new Prophet({ optimizer });
       prophet.fit({ ds, y });
 
-      const future = prophet.makeFutureDataFrame(10);
+      const future = prophet.makeFutureDataframe(10);
       expect(future.ds).toHaveLength(10 + TOTAL_LENGTH);
 
       for (let i = 1; i < future.ds.length; i++) {

--- a/js/testpkg/prophet.test.ts
+++ b/js/testpkg/prophet.test.ts
@@ -110,7 +110,7 @@ describe('Prophet', () => {
       }
     });
 
-    it('can be called with horizon with history as default option', () => {
+    it('can be called with only horizon and no options argument', () => {
       const prophet = new Prophet({ optimizer });
       prophet.fit({ ds, y });
 
@@ -120,6 +120,14 @@ describe('Prophet', () => {
       for (let i = 1; i < future.ds.length; i++) {
         expect(future.ds[i] - future.ds[i - 1]).toBe(NINE_DAYS);
       }
+    });
+
+    it('can be called with horizon and empty options argument', () => {
+      const prophet = new Prophet({ optimizer });
+      prophet.fit({ ds, y });
+
+      const future = prophet.makeFutureDataframe(10, {});
+      expect(future.ds).toHaveLength(10 + TOTAL_LENGTH);
     });
   });
 });


### PR DESCRIPTION
Related to #167 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the accessibility of prediction data fields for better integration and usage.
  - Added a new method `make_future_dataframe` to the `Prophet` struct for creating dates for predictions.
- **Documentation**
  - Improved documentation clarity for the fields in the `PredictionData` struct.
- **Tests**
  - Introduced new test scenarios for the `makeFutureDataframe` method to validate the output with and without historical data.
  - Updated test data initialization for improved flexibility and scalability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->