### PR TITLE
chore: pin zip to 2.5.0 for now

### DIFF
--- a/crates/augurs-clustering/src/lib.rs
+++ b/crates/augurs-clustering/src/lib.rs
@@ -71,9 +71,9 @@ impl DbscanClusterer {
     ///
     /// # Arguments
     /// * `epsilon` - The maximum distance between two samples for one to be considered as in the
-    ///     neighborhood of the other.
+    ///   neighborhood of the other.
     /// * `min_cluster_size` - The number of samples in a neighborhood for a point to be considered as a core
-    ///     point.
+    ///   point.
     pub fn new(epsilon: f64, min_cluster_size: usize) -> Self {
         Self {
             epsilon,

--- a/crates/augurs-ets/src/model.rs
+++ b/crates/augurs-ets/src/model.rs
@@ -559,7 +559,7 @@ impl Unfit {
                 let X = DMatrix::from_iterator(
                     max_n,
                     2,
-                    std::iter::repeat(1.0)
+                    std::iter::repeat_n(1.0, max_n)
                         .take(max_n)
                         .chain((1..(max_n + 1)).map(|x| x as f64)),
                 );
@@ -1333,7 +1333,7 @@ impl Forecast<'_> {
                 // Class 2 models.
                 // MNN
                 (EC::Multiplicative, TC::None, SC::None, false) => {
-                    let cvals = std::iter::repeat(*alpha).take(horizon);
+                    let cvals = std::iter::repeat_n(*alpha, horizon);
                     let sigma_h = self.compute_sigma_h(sigma, cvals, horizon);
                     self.compute_intervals(level, sigma_h.into_iter())
                 }

--- a/crates/augurs-prophet/Cargo.toml
+++ b/crates/augurs-prophet/Cargo.toml
@@ -44,7 +44,7 @@ wasmtime = { version = "29", features = [
     "component-model",
 ], optional = true }
 wasmtime-wasi = { version = "29", optional = true }
-zip = { version = "2.2.0", optional = true }
+zip = { version = "=2.5.0", optional = true }
 
 [dev-dependencies]
 augurs.workspace = true

--- a/crates/augurs-prophet/src/forecaster.rs
+++ b/crates/augurs-prophet/src/forecaster.rs
@@ -27,8 +27,8 @@ impl ProphetForecaster {
     /// # Parameters
     ///
     /// - `opts`: The options to use for fitting the model.
-    ///           Note that `uncertainty_samples` will be set to 1000 if it is 0,
-    ///           to facilitate generating prediction intervals.
+    ///   Note that `uncertainty_samples` will be set to 1000 if it is 0,
+    ///   to facilitate generating prediction intervals.
     /// - `optimizer`: The optimizer to use for fitting the model.
     /// - `optimize_opts`: The options to use for optimizing the model.
     pub fn new<T: Optimizer + 'static>(

--- a/crates/augurs-prophet/src/prophet/predict.rs
+++ b/crates/augurs-prophet/src/prophet/predict.rs
@@ -171,7 +171,7 @@ impl<O> Prophet<O> {
         // Repeat each changepoint effect `n` times so we can zip it up.
         let changepoints_repeated = changepoints_t
             .iter()
-            .flat_map(|x| std::iter::repeat(*x).take(t.len()));
+            .flat_map(|x| std::iter::repeat_n(*x, t.len()));
         let indexes = (0..t.len()).cycle();
         // `k_m_t` is a contiguous array where each element contains the rate and offset to
         // apply at each time point.
@@ -228,7 +228,7 @@ impl<O> Prophet<O> {
 
     /// Evaluate the flat trend function.
     fn flat_trend(t: &[f64], m: f64) -> impl Iterator<Item = f64> {
-        std::iter::repeat(m).take(t.len())
+        std::iter::repeat_n(m, t.len())
     }
 
     /// Predict seasonality, holidays and added regressors.

--- a/crates/augurs-prophet/src/prophet/prep.rs
+++ b/crates/augurs-prophet/src/prophet/prep.rs
@@ -713,7 +713,7 @@ impl<O> Prophet<O> {
             let prior_scale = seasonality
                 .prior_scale
                 .unwrap_or(self.opts.seasonality_prior_scale);
-            prior_scales.extend(std::iter::repeat(prior_scale).take(n_new));
+            prior_scales.extend(std::iter::repeat_n(prior_scale, n_new));
             modes.insert(
                 seasonality.mode.unwrap_or(self.opts.seasonality_mode),
                 ComponentName::Seasonality(name.clone()),


### PR DESCRIPTION
2.6.x introduced semver incompatible changes which may be yanked.
See https://github.com/zip-rs/zip2/issues/337.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated internal dependency versioning for improved consistency. No changes to user-facing features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->