### PR TITLE
chore: bump pyo3 and rust-numpy to 0.24

### DIFF
--- a/crates/augurs-prophet/Cargo.toml
+++ b/crates/augurs-prophet/Cargo.toml
@@ -44,7 +44,7 @@ wasmtime = { version = "29", features = [
     "component-model",
 ], optional = true }
 wasmtime-wasi = { version = "29", optional = true }
-zip = { version = "=2.5.0", optional = true }
+zip = { version = "3", optional = true }
 
 [dev-dependencies]
 augurs.workspace = true

--- a/crates/augurs-prophet/src/bin/main.rs
+++ b/crates/augurs-prophet/src/bin/main.rs
@@ -108,7 +108,7 @@ fn unzip(dest: &Path) -> Result<()> {
     anyhow::bail!("could not find one or more of prophet_model.bin or libtbb.so");
 }
 
-fn write(dest: &Path, file: ZipFile<'_>) -> Result<()> {
+fn write<R: Read>(dest: &Path, file: ZipFile<'_, R>) -> Result<()> {
     let file_path = file.enclosed_name().context("invalid file name in wheel")?;
     let name = file_path.file_name().context("file has no name?")?;
     let path = dest.join(name);

--- a/crates/pyaugurs/Cargo.toml
+++ b/crates/pyaugurs/Cargo.toml
@@ -26,8 +26,8 @@ augurs-ets = { workspace = true, features = ["mstl"] }
 augurs-forecaster.workspace = true
 augurs-mstl.workspace = true
 augurs-seasons.workspace = true
-numpy = "0.23.0"
-pyo3 = { version = "0.23.3", features = ["extension-module"] }
+numpy = "0.24.0"
+pyo3 = { version = "0.24.0", features = ["extension-module"] }
 tracing = { version = "0.1.37", features = ["log"] }
 
 [lints]


### PR DESCRIPTION
They need to be kept in sync, so dependabot's update won't work.
