### PR TITLE
chore: remove pprof from benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,6 @@ wasm-bindgen = "0.2.99"
 assert_approx_eq = "1.1.0"
 criterion = "0.5.1"
 iai = "0.1.1"
-pprof = { version = "0.14.0", features = ["criterion", "frame-pointer", "prost-codec"] }
 pretty_assertions = "1.4.1"
 
 [workspace.lints.rust]

--- a/crates/augurs-changepoint/Cargo.toml
+++ b/crates/augurs-changepoint/Cargo.toml
@@ -33,7 +33,6 @@ augurs.workspace = true
 augurs-testing.workspace = true
 criterion.workspace = true
 iai.workspace = true
-pprof.workspace = true
 
 [lints]
 workspace = true

--- a/crates/augurs-ets/Cargo.toml
+++ b/crates/augurs-ets/Cargo.toml
@@ -31,7 +31,6 @@ serde = ["dep:serde"]
 augurs-testing.workspace = true
 criterion.workspace = true
 iai.workspace = true
-pprof.workspace = true
 
 [lib]
 bench = false

--- a/crates/augurs-ets/benches/air_passengers.rs
+++ b/crates/augurs-ets/benches/air_passengers.rs
@@ -1,7 +1,6 @@
 #![allow(missing_docs)]
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use pprof::criterion::{Output, PProfProfiler};
 
 use augurs_core::{Fit, Predict};
 use augurs_ets::{
@@ -60,8 +59,7 @@ fn forecast(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    // config = Criterion::default();
-    config = Criterion::default().with_profiler(PProfProfiler::new(10000, Output::Protobuf));
+    config = Criterion::default();
     targets = auto_fit, fit, forecast,
 }
 criterion_main!(benches);

--- a/crates/augurs-mstl/Cargo.toml
+++ b/crates/augurs-mstl/Cargo.toml
@@ -26,7 +26,6 @@ augurs.workspace = true
 augurs-testing.workspace = true
 criterion.workspace = true
 iai.workspace = true
-pprof.workspace = true
 
 [[bench]]
 name = "vic_elec"

--- a/crates/augurs-mstl/benches/vic_elec.rs
+++ b/crates/augurs-mstl/benches/vic_elec.rs
@@ -1,7 +1,6 @@
 #![allow(missing_docs)]
 
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
-use pprof::criterion::{Output, PProfProfiler};
 
 use augurs_core::Fit;
 use augurs_mstl::{MSTLModel, NaiveTrend};
@@ -36,7 +35,7 @@ fn vic_elec(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Protobuf));
+    config = Criterion::default();
     targets = vic_elec
 }
 criterion_main!(benches);

--- a/crates/augurs-seasons/Cargo.toml
+++ b/crates/augurs-seasons/Cargo.toml
@@ -23,7 +23,6 @@ welch-sde = "0.1.0"
 augurs.workspace = true
 augurs-testing.workspace = true
 criterion.workspace = true
-pprof.workspace = true
 
 [[bench]]
 name = "periodogram"

--- a/crates/augurs-seasons/benches/periodogram.rs
+++ b/crates/augurs-seasons/benches/periodogram.rs
@@ -1,7 +1,6 @@
 #![allow(missing_docs)]
 
 use criterion::{criterion_group, criterion_main, Criterion};
-use pprof::criterion::{Output, PProfProfiler};
 
 use augurs_seasons::{Detector, PeriodogramDetector};
 use augurs_testing::data::SEASON_EIGHT;
@@ -16,7 +15,7 @@ fn season_eight(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Protobuf));
+    config = Criterion::default();
     targets = season_eight
 }
 criterion_main!(benches);


### PR DESCRIPTION
I tend to use samply for benchmarks instead now, and I want to update
criterion to a version that pprof doesn't support yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the profiling tool integration from benchmarking setups across multiple crates.
	- Eliminated related development dependencies for a cleaner and lighter development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->