### PR TITLE
chore(deps): bump pyo3 and rust-numpy to 0.25

### DIFF
--- a/crates/pyaugurs/Cargo.toml
+++ b/crates/pyaugurs/Cargo.toml
@@ -26,8 +26,8 @@ augurs-ets = { workspace = true, features = ["mstl"] }
 augurs-forecaster.workspace = true
 augurs-mstl.workspace = true
 augurs-seasons.workspace = true
-numpy = "0.24.0"
-pyo3 = { version = "0.24.0", features = ["extension-module"] }
+numpy = "0.25.0"
+pyo3 = { version = "0.25.0", features = ["extension-module"] }
 tracing = { version = "0.1.37", features = ["log"] }
 
 [lints]


### PR DESCRIPTION
Turns out v0.25 is out, let's bump further.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal dependencies to newer versions for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->