### PR TITLE
chore(deps): bump criterion to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ tsify-next = { version = "0.5.3", default-features = false, features = ["js"] }
 wasm-bindgen = "0.2.99"
 
 assert_approx_eq = "1.1.0"
-criterion = "0.5.1"
+criterion = "0.6.0"
 iai = "0.1.1"
 pretty_assertions = "1.4.1"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the benchmarking library to a newer version for improved performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->