### PR TITLE
chore: release v0.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## `augurs-seasons` - [0.10.1](https://github.com/grafana/augurs/compare/augurs-seasons-v0.10.0...augurs-seasons-v0.10.1) - 2025-08-18
+
+### Fixed
+- fix clippy lints for Rust 1.88 ([#315](https://github.com/grafana/augurs/pull/315))
+
+## `augurs-prophet` - [0.10.1](https://github.com/grafana/augurs/compare/augurs-prophet-v0.10.0...augurs-prophet-v0.10.1) - 2025-08-18
+
+### Fixed
+- fix clippy lints for Rust 1.88 ([#315](https://github.com/grafana/augurs/pull/315))
+- *(prophet)* use holiday prior scale for regressors ([#305](https://github.com/grafana/augurs/pull/305))
+
+## `augurs-outlier` - [0.10.1](https://github.com/grafana/augurs/compare/augurs-outlier-v0.10.0...augurs-outlier-v0.10.1) - 2025-08-18
+
+### Other
+- allow dead code in outlier detector test to serve as example
+
+## `augurs-ets` - [0.10.1](https://github.com/grafana/augurs/compare/augurs-ets-v0.10.0...augurs-ets-v0.10.1) - 2025-08-18
+
+### Fixed
+- fix clippy lints for Rust 1.88 ([#315](https://github.com/grafana/augurs/pull/315))
+
+## `augurs-dtw` - [0.10.1](https://github.com/grafana/augurs/compare/augurs-dtw-v0.10.0...augurs-dtw-v0.10.1) - 2025-08-18
+
+### Fixed
+- fix clippy lints for Rust 1.88 ([#315](https://github.com/grafana/augurs/pull/315))
+
 ## [0.10.0](https://github.com/grafana/augurs/compare/augurs-v0.9.0...augurs-v0.10.0) - 2025-05-19
 
 ### `augurs-seasons`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ authors = [
 ]
 documentation = "https://docs.rs/crate/augurs"
 repository = "https://github.com/grafana/augurs"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 keywords = [
   "analysis",
@@ -29,16 +29,16 @@ keywords = [
 
 [workspace.dependencies]
 augurs = { path = "crates/augurs" }
-augurs-changepoint = { version = "0.10.0", path = "crates/augurs-changepoint" }
-augurs-clustering = { version = "0.10.0", path = "crates/augurs-clustering" }
-augurs-core = { version = "0.10.0", path = "crates/augurs-core" }
-augurs-dtw = { version = "0.10.0", path = "crates/augurs-dtw" }
-augurs-ets = { version = "0.10.0", path = "crates/augurs-ets" }
-augurs-forecaster = { version = "0.10.0", path = "crates/augurs-forecaster" }
-augurs-mstl = { version = "0.10.0", path = "crates/augurs-mstl" }
-augurs-outlier = { version = "0.10.0", path = "crates/augurs-outlier" }
-augurs-prophet = { version = "0.10.0", path = "crates/augurs-prophet" }
-augurs-seasons = { version = "0.10.0", path = "crates/augurs-seasons" }
+augurs-changepoint = { version = "0.10.1", path = "crates/augurs-changepoint" }
+augurs-clustering = { version = "0.10.1", path = "crates/augurs-clustering" }
+augurs-core = { version = "0.10.1", path = "crates/augurs-core" }
+augurs-dtw = { version = "0.10.1", path = "crates/augurs-dtw" }
+augurs-ets = { version = "0.10.1", path = "crates/augurs-ets" }
+augurs-forecaster = { version = "0.10.1", path = "crates/augurs-forecaster" }
+augurs-mstl = { version = "0.10.1", path = "crates/augurs-mstl" }
+augurs-outlier = { version = "0.10.1", path = "crates/augurs-outlier" }
+augurs-prophet = { version = "0.10.1", path = "crates/augurs-prophet" }
+augurs-seasons = { version = "0.10.1", path = "crates/augurs-seasons" }
 augurs-testing = { path = "crates/augurs-testing" }
 
 augurs-core-js = { path = "js/augurs-core-js" }


### PR DESCRIPTION



## 🤖 New release

* `augurs-core`: 0.10.0 -> 0.10.1
* `augurs-changepoint`: 0.10.0 -> 0.10.1
* `augurs-clustering`: 0.10.0 -> 0.10.1
* `augurs-dtw`: 0.10.0 -> 0.10.1 (✓ API compatible changes)
* `augurs-mstl`: 0.10.0 -> 0.10.1
* `augurs-ets`: 0.10.0 -> 0.10.1 (✓ API compatible changes)
* `augurs-forecaster`: 0.10.0 -> 0.10.1
* `augurs-outlier`: 0.10.0 -> 0.10.1 (✓ API compatible changes)
* `augurs-prophet`: 0.10.0 -> 0.10.1 (✓ API compatible changes)
* `augurs-seasons`: 0.10.0 -> 0.10.1 (✓ API compatible changes)
* `augurs`: 0.10.0 -> 0.10.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `augurs-core`

<blockquote>

## [0.10.0](https://github.com/grafana/augurs/compare/augurs-v0.9.0...augurs-v0.10.0) - 2025-05-19

### `augurs-seasons`

No changes in this release.

### `augurs-prophet`

- Add JS bindings for Prophet make_future_dataframe ([#257](https://github.com/grafana/augurs/pull/257), by @shenxiangzhuang)
- *(deps)* bump zipfile to 3.x ([#286](https://github.com/grafana/augurs/pull/286))
- *(deps)* update ureq requirement from 2.10.1 to 3.0.0 ([#245](https://github.com/grafana/augurs/pull/245))
- *(deps)* bump wasmtime and wasmtime-wasi to 32 ([#289](https://github.com/grafana/augurs/pull/289))

### `augurs-outlier`

#### Added
- add setters for parameters ([#253](https://github.com/grafana/augurs/pull/253), by @shenxiangzhuang)

### `augurs-ets`

No changes in this release.

### `augurs-mstl`

No changes in this release.

### `augurs-dtw`

No changes in this release.

### `augurs-clustering`

No changes in this release.

### `augurs-changepoint`

No changes in this release.
</blockquote>

## `augurs-changepoint`

<blockquote>

## [0.10.0](https://github.com/grafana/augurs/compare/augurs-v0.9.0...augurs-v0.10.0) - 2025-05-19

### `augurs-seasons`

No changes in this release.

### `augurs-prophet`

- Add JS bindings for Prophet make_future_dataframe ([#257](https://github.com/grafana/augurs/pull/257), by @shenxiangzhuang)
- *(deps)* bump zipfile to 3.x ([#286](https://github.com/grafana/augurs/pull/286))
- *(deps)* update ureq requirement from 2.10.1 to 3.0.0 ([#245](https://github.com/grafana/augurs/pull/245))
- *(deps)* bump wasmtime and wasmtime-wasi to 32 ([#289](https://github.com/grafana/augurs/pull/289))

### `augurs-outlier`

#### Added
- add setters for parameters ([#253](https://github.com/grafana/augurs/pull/253), by @shenxiangzhuang)

### `augurs-ets`

No changes in this release.

### `augurs-mstl`

No changes in this release.

### `augurs-dtw`

No changes in this release.

### `augurs-clustering`

No changes in this release.

### `augurs-changepoint`

No changes in this release.
</blockquote>

## `augurs-clustering`

<blockquote>

## [0.10.0](https://github.com/grafana/augurs/compare/augurs-v0.9.0...augurs-v0.10.0) - 2025-05-19

### `augurs-seasons`

No changes in this release.

### `augurs-prophet`

- Add JS bindings for Prophet make_future_dataframe ([#257](https://github.com/grafana/augurs/pull/257), by @shenxiangzhuang)
- *(deps)* bump zipfile to 3.x ([#286](https://github.com/grafana/augurs/pull/286))
- *(deps)* update ureq requirement from 2.10.1 to 3.0.0 ([#245](https://github.com/grafana/augurs/pull/245))
- *(deps)* bump wasmtime and wasmtime-wasi to 32 ([#289](https://github.com/grafana/augurs/pull/289))

### `augurs-outlier`

#### Added
- add setters for parameters ([#253](https://github.com/grafana/augurs/pull/253), by @shenxiangzhuang)

### `augurs-ets`

No changes in this release.

### `augurs-mstl`

No changes in this release.

### `augurs-dtw`

No changes in this release.

### `augurs-clustering`

No changes in this release.

### `augurs-changepoint`

No changes in this release.
</blockquote>

## `augurs-dtw`

<blockquote>

## [0.10.0](https://github.com/grafana/augurs/compare/augurs-v0.9.0...augurs-v0.10.0) - 2025-05-19

### `augurs-seasons`

No changes in this release.

### `augurs-prophet`

- Add JS bindings for Prophet make_future_dataframe ([#257](https://github.com/grafana/augurs/pull/257), by @shenxiangzhuang)
- *(deps)* bump zipfile to 3.x ([#286](https://github.com/grafana/augurs/pull/286))
- *(deps)* update ureq requirement from 2.10.1 to 3.0.0 ([#245](https://github.com/grafana/augurs/pull/245))
- *(deps)* bump wasmtime and wasmtime-wasi to 32 ([#289](https://github.com/grafana/augurs/pull/289))

### `augurs-outlier`

#### Added
- add setters for parameters ([#253](https://github.com/grafana/augurs/pull/253), by @shenxiangzhuang)

### `augurs-ets`

No changes in this release.

### `augurs-mstl`

No changes in this release.

### `augurs-dtw`

No changes in this release.

### `augurs-clustering`

No changes in this release.

### `augurs-changepoint`

No changes in this release.
</blockquote>

## `augurs-mstl`

<blockquote>

## [0.10.0](https://github.com/grafana/augurs/compare/augurs-v0.9.0...augurs-v0.10.0) - 2025-05-19

### `augurs-seasons`

No changes in this release.

### `augurs-prophet`

- Add JS bindings for Prophet make_future_dataframe ([#257](https://github.com/grafana/augurs/pull/257), by @shenxiangzhuang)
- *(deps)* bump zipfile to 3.x ([#286](https://github.com/grafana/augurs/pull/286))
- *(deps)* update ureq requirement from 2.10.1 to 3.0.0 ([#245](https://github.com/grafana/augurs/pull/245))
- *(deps)* bump wasmtime and wasmtime-wasi to 32 ([#289](https://github.com/grafana/augurs/pull/289))

### `augurs-outlier`

#### Added
- add setters for parameters ([#253](https://github.com/grafana/augurs/pull/253), by @shenxiangzhuang)

### `augurs-ets`

No changes in this release.

### `augurs-mstl`

No changes in this release.

### `augurs-dtw`

No changes in this release.

### `augurs-clustering`

No changes in this release.

### `augurs-changepoint`

No changes in this release.
</blockquote>

## `augurs-ets`

<blockquote>

## [0.10.0](https://github.com/grafana/augurs/compare/augurs-v0.9.0...augurs-v0.10.0) - 2025-05-19

### `augurs-seasons`

No changes in this release.

### `augurs-prophet`

- Add JS bindings for Prophet make_future_dataframe ([#257](https://github.com/grafana/augurs/pull/257), by @shenxiangzhuang)
- *(deps)* bump zipfile to 3.x ([#286](https://github.com/grafana/augurs/pull/286))
- *(deps)* update ureq requirement from 2.10.1 to 3.0.0 ([#245](https://github.com/grafana/augurs/pull/245))
- *(deps)* bump wasmtime and wasmtime-wasi to 32 ([#289](https://github.com/grafana/augurs/pull/289))

### `augurs-outlier`

#### Added
- add setters for parameters ([#253](https://github.com/grafana/augurs/pull/253), by @shenxiangzhuang)

### `augurs-ets`

No changes in this release.

### `augurs-mstl`

No changes in this release.

### `augurs-dtw`

No changes in this release.

### `augurs-clustering`

No changes in this release.

### `augurs-changepoint`

No changes in this release.
</blockquote>

## `augurs-forecaster`

<blockquote>

## [0.10.0](https://github.com/grafana/augurs/compare/augurs-v0.9.0...augurs-v0.10.0) - 2025-05-19

### `augurs-seasons`

No changes in this release.

### `augurs-prophet`

- Add JS bindings for Prophet make_future_dataframe ([#257](https://github.com/grafana/augurs/pull/257), by @shenxiangzhuang)
- *(deps)* bump zipfile to 3.x ([#286](https://github.com/grafana/augurs/pull/286))
- *(deps)* update ureq requirement from 2.10.1 to 3.0.0 ([#245](https://github.com/grafana/augurs/pull/245))
- *(deps)* bump wasmtime and wasmtime-wasi to 32 ([#289](https://github.com/grafana/augurs/pull/289))

### `augurs-outlier`

#### Added
- add setters for parameters ([#253](https://github.com/grafana/augurs/pull/253), by @shenxiangzhuang)

### `augurs-ets`

No changes in this release.

### `augurs-mstl`

No changes in this release.

### `augurs-dtw`

No changes in this release.

### `augurs-clustering`

No changes in this release.

### `augurs-changepoint`

No changes in this release.
</blockquote>

## `augurs-outlier`

<blockquote>

## [0.10.0](https://github.com/grafana/augurs/compare/augurs-v0.9.0...augurs-v0.10.0) - 2025-05-19

### `augurs-seasons`

No changes in this release.

### `augurs-prophet`

- Add JS bindings for Prophet make_future_dataframe ([#257](https://github.com/grafana/augurs/pull/257), by @shenxiangzhuang)
- *(deps)* bump zipfile to 3.x ([#286](https://github.com/grafana/augurs/pull/286))
- *(deps)* update ureq requirement from 2.10.1 to 3.0.0 ([#245](https://github.com/grafana/augurs/pull/245))
- *(deps)* bump wasmtime and wasmtime-wasi to 32 ([#289](https://github.com/grafana/augurs/pull/289))

### `augurs-outlier`

#### Added
- add setters for parameters ([#253](https://github.com/grafana/augurs/pull/253), by @shenxiangzhuang)

### `augurs-ets`

No changes in this release.

### `augurs-mstl`

No changes in this release.

### `augurs-dtw`

No changes in this release.

### `augurs-clustering`

No changes in this release.

### `augurs-changepoint`

No changes in this release.
</blockquote>

## `augurs-prophet`

<blockquote>

## [0.10.0](https://github.com/grafana/augurs/compare/augurs-v0.9.0...augurs-v0.10.0) - 2025-05-19

### `augurs-seasons`

No changes in this release.

### `augurs-prophet`

- Add JS bindings for Prophet make_future_dataframe ([#257](https://github.com/grafana/augurs/pull/257), by @shenxiangzhuang)
- *(deps)* bump zipfile to 3.x ([#286](https://github.com/grafana/augurs/pull/286))
- *(deps)* update ureq requirement from 2.10.1 to 3.0.0 ([#245](https://github.com/grafana/augurs/pull/245))
- *(deps)* bump wasmtime and wasmtime-wasi to 32 ([#289](https://github.com/grafana/augurs/pull/289))

### `augurs-outlier`

#### Added
- add setters for parameters ([#253](https://github.com/grafana/augurs/pull/253), by @shenxiangzhuang)

### `augurs-ets`

No changes in this release.

### `augurs-mstl`

No changes in this release.

### `augurs-dtw`

No changes in this release.

### `augurs-clustering`

No changes in this release.

### `augurs-changepoint`

No changes in this release.
</blockquote>

## `augurs-seasons`

<blockquote>

## [0.10.0](https://github.com/grafana/augurs/compare/augurs-v0.9.0...augurs-v0.10.0) - 2025-05-19

### `augurs-seasons`

No changes in this release.

### `augurs-prophet`

- Add JS bindings for Prophet make_future_dataframe ([#257](https://github.com/grafana/augurs/pull/257), by @shenxiangzhuang)
- *(deps)* bump zipfile to 3.x ([#286](https://github.com/grafana/augurs/pull/286))
- *(deps)* update ureq requirement from 2.10.1 to 3.0.0 ([#245](https://github.com/grafana/augurs/pull/245))
- *(deps)* bump wasmtime and wasmtime-wasi to 32 ([#289](https://github.com/grafana/augurs/pull/289))

### `augurs-outlier`

#### Added
- add setters for parameters ([#253](https://github.com/grafana/augurs/pull/253), by @shenxiangzhuang)

### `augurs-ets`

No changes in this release.

### `augurs-mstl`

No changes in this release.

### `augurs-dtw`

No changes in this release.

### `augurs-clustering`

No changes in this release.

### `augurs-changepoint`

No changes in this release.
</blockquote>

## `augurs`

<blockquote>

## [0.10.0](https://github.com/grafana/augurs/compare/augurs-v0.9.0...augurs-v0.10.0) - 2025-05-19

### `augurs-seasons`

No changes in this release.

### `augurs-prophet`

- Add JS bindings for Prophet make_future_dataframe ([#257](https://github.com/grafana/augurs/pull/257), by @shenxiangzhuang)
- *(deps)* bump zipfile to 3.x ([#286](https://github.com/grafana/augurs/pull/286))
- *(deps)* update ureq requirement from 2.10.1 to 3.0.0 ([#245](https://github.com/grafana/augurs/pull/245))
- *(deps)* bump wasmtime and wasmtime-wasi to 32 ([#289](https://github.com/grafana/augurs/pull/289))

### `augurs-outlier`

#### Added
- add setters for parameters ([#253](https://github.com/grafana/augurs/pull/253), by @shenxiangzhuang)

### `augurs-ets`

No changes in this release.

### `augurs-mstl`

No changes in this release.

### `augurs-dtw`

No changes in this release.

### `augurs-clustering`

No changes in this release.

### `augurs-changepoint`

No changes in this release.
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected application of holiday prior scale for regressors in Prophet-based models, improving forecast consistency.
- Chores
  - Bumped all workspace packages to version 0.10.1.
  - Performed maintenance updates for compatibility with Rust 1.88.
- Documentation
  - Updated changelog with unreleased 0.10.1 entries across multiple packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->