### PR TITLE
chore: use Vault instead of GitHub secrets

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -177,10 +177,16 @@ jobs:
         uses: actions/attest-build-provenance@db473fddc028af60658334401dc6fa3ffd8669fd # v2.3.0
         with:
           subject-path: "wheels-*/*"
+
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b # get-vault-secrets-v1.2.0
+        with:
+          # Secrets placed in the ci/repo/grafana/augurs/<path> path in Vault
+          repo_secrets: |
+            MATURIN_PYPI_TOKEN=pypi:api-token
+
       - name: Publish to PyPI
         uses: PyO3/maturin-action@aef21716ff3dcae8a1c301d23ec3e4446972a6e3 # v1.49.1
-        env:
-          MATURIN_PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository_owner == 'grafana' }}
     permissions:
+      # Required to get secrets from Vault.
+      id-token: write
       contents: write
     steps:
       - name: Checkout repository
@@ -25,19 +27,27 @@ jobs:
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
         with:
           toolchain: stable
+
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b # get-vault-secrets-v1.2.0
+        with:
+          # Secrets placed in the ci/repo/grafana/augurs/<path> path in Vault
+          repo_secrets: |
+            CARGO_REGISTRY_TOKEN=crates-io:api-token
+            GITHUB_TOKEN=github:token
+
       - name: Run release-plz
         uses: release-plz/action@dde7b63054529c440305a924e5849c68318bcc9a # v0.5.107
         with:
           command: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   # Create a PR with the new versions and changelog, preparing the next release.
   release-plz-pr:
     name: Release-plz PR
     runs-on: ubuntu-latest
     permissions:
+      # Required to get secrets from Vault.
+      id-token: write
       contents: write
       pull-requests: write
     concurrency:
@@ -53,10 +63,16 @@ jobs:
         uses: dtolnay/rust-toolchain@b3b07ba8b418998c39fb20f53e8b695cdcc8de1b
         with:
           toolchain: stable
+
+      - id: get-secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@5d7e361bc7e0a183cde8afe9899fb7b596d2659b # get-vault-secrets-v1.2.0
+        with:
+          # Secrets placed in the ci/repo/grafana/augurs/<path> path in Vault
+          repo_secrets: |
+            CARGO_REGISTRY_TOKEN=crates-io:api-token
+            GITHUB_TOKEN=github:token
+
       - name: Run release-plz
         uses: release-plz/action@dde7b63054529c440305a924e5849c68318bcc9a # v0.5.107
         with:
           command: release-pr
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
GitHub secrets will be removed soon in favour of Vault.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated release workflows to fetch publishing secrets securely from Vault instead of using GitHub Actions secrets directly.
	- Adjusted permissions in workflows to support secret retrieval from Vault.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->