### PR TITLE
fix(prophet): use holiday prior scale for regressors

### DIFF
--- a/crates/augurs-prophet/CHANGELOG.md
+++ b/crates/augurs-prophet/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- fix regressors defaulting to seasonality prior scale instead of holiday prior scale (#256)
+
 ## [0.8.1](https://github.com/grafana/augurs/compare/augurs-prophet-v0.8.0...augurs-prophet-v0.8.1) - 2025-01-07
 
 ### Fixed

--- a/crates/augurs-prophet/src/features.rs
+++ b/crates/augurs-prophet/src/features.rs
@@ -192,7 +192,7 @@ impl Default for RegressorScale {
 
 /// An exogynous regressor.
 ///
-/// By default, regressors inherit the `seasonality_prior_scale`
+/// By default, regressors inherit the `holidays_prior_scale`
 /// configured on the Prophet model as their prior scale.
 #[derive(Debug, Clone, Default)]
 pub struct Regressor {
@@ -220,7 +220,7 @@ impl Regressor {
 
     /// Set the prior scale of this regressor.
     ///
-    /// By default, regressors inherit the `seasonality_prior_scale`
+    /// By default, regressors inherit the `holidays_prior_scale`
     /// configured on the Prophet model as their prior scale.
     pub fn with_prior_scale(mut self, prior_scale: PositiveFloat) -> Self {
         self.prior_scale = Some(prior_scale);


### PR DESCRIPTION
Fixes #256.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where regressors incorrectly defaulted to the seasonality prior scale; they now correctly default to the holiday prior scale.
- **Documentation**
  - Updated documentation to clarify that regressors inherit the holiday prior scale by default.
- **Tests**
  - Added a test to verify that regressors default to the holiday prior scale when not explicitly set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->