### PR TITLE
fix: fix clippy lints for Rust 1.88

### DIFF
--- a/crates/augurs-dtw/benches/dtw.rs
+++ b/crates/augurs-dtw/benches/dtw.rs
@@ -28,7 +28,7 @@ fn distance_euclidean(c: &mut Criterion) {
     let windows = [None, Some(2), Some(5), Some(10), Some(20), Some(50)];
     for window in windows {
         group.bench_with_input(
-            BenchmarkId::from_parameter(format!("{:?}", window)),
+            BenchmarkId::from_parameter(format!("{window:?}")),
             &(s, t),
             |b, (s, t)| {
                 b.iter(|| {
@@ -52,8 +52,7 @@ fn distance_matrix_euclidean(c: &mut Criterion) {
     for (window, parallelize) in windows.into_iter().cartesian_product(parallelize) {
         group.bench_with_input(
             BenchmarkId::from_parameter(format!(
-                "window: {:?}, parallelize: {:?}",
-                window, parallelize
+                "window: {window:?}, parallelize: {parallelize:?}"
             )),
             &examples,
             |b, examples| {

--- a/crates/augurs-ets/src/auto.rs
+++ b/crates/augurs-ets/src/auto.rs
@@ -604,17 +604,13 @@ mod test {
                 ("N", _, _) => {
                     assert!(
                         matches!(spec, Err(Error::InvalidErrorComponentString(_))),
-                        "{:?}, case {}",
-                        spec,
-                        case
+                        "{spec:?}, case {case}"
                     );
                 }
                 ("A", "M", _) | ("A", _, "M") | ("M", "M", "M") => {
                     assert!(
                         matches!(spec, Err(Error::InvalidModelSpec(_))),
-                        "{:?}, case {}",
-                        spec,
-                        case
+                        "{spec:?}, case {case}"
                     );
                 }
                 _ => {

--- a/crates/augurs-prophet/build.rs
+++ b/crates/augurs-prophet/build.rs
@@ -40,7 +40,7 @@ fn compile_cmdstan_model() -> Result<(), Box<dyn std::error::Error>> {
     eprintln!("Compiling Prophet model to {}", tmp_exe_path.display());
     let mut cmd = Command::new("make");
     cmd.current_dir(cmdstan_bin_path).arg(&tmp_exe_path);
-    eprintln!("Executing {:?}", cmd);
+    eprintln!("Executing {cmd:?}");
     let output = cmd.output()?;
     if !output.status.success() {
         return Err(format!("make failed: {}", String::from_utf8_lossy(&output.stderr)).into());

--- a/crates/augurs-prophet/src/cmdstan.rs
+++ b/crates/augurs-prophet/src/cmdstan.rs
@@ -75,7 +75,7 @@ pub enum Error {
         source: io::Error,
     },
     /// An error occurred when running the Prophet model executable.
-    #[error("Error {}running Prophet command ({command}): {stdout}\n{stderr}", code.map(|c| format!("code {}", c)).unwrap_or_default())]
+    #[error("Error {}running Prophet command ({command}): {stdout}\n{stderr}", code.map(|c| format!("code {c}")).unwrap_or_default())]
     ProphetExeError {
         /// The stringified command that was attempted.
         command: String,
@@ -392,7 +392,7 @@ impl OptimizeCommand<'_> {
         let mut command = self.command(&data_path, &init_path, &output_path);
         command.stdout(Stdio::piped()).stderr(Stdio::piped());
         let mut handle = command.spawn().map_err(|source| Error::ProphetIOError {
-            command: format!("{:?}", command),
+            command: format!("{command:?}"),
             source,
         })?;
         // Capture the output.
@@ -419,7 +419,7 @@ impl OptimizeCommand<'_> {
                     // If the child exited with a non-zero status, return an error.
                     if !status.success() {
                         return Err(Error::ProphetExeError {
-                            command: format!("{:?}", command),
+                            command: format!("{command:?}"),
                             code: status.code(),
                             stdout: stdout_reader.all_stdout,
                             stderr: stderr_reader.all_stdout,
@@ -430,7 +430,7 @@ impl OptimizeCommand<'_> {
                 Err(e) => {
                     // Error while waiting for child, return an error.
                     return Err(Error::ProphetIOError {
-                        command: format!("{:?}", command),
+                        command: format!("{command:?}"),
                         source: e,
                     });
                 }
@@ -638,12 +638,12 @@ impl CmdstanOptimizer {
         let mut command = prophet_installation.command();
         command.arg("help");
         let output = command.output().map_err(|source| Error::ProphetIOError {
-            command: format!("{:?}", command),
+            command: format!("{command:?}"),
             source,
         })?;
         if !output.status.success() {
             return Err(Error::ProphetExeError {
-                command: format!("{:?}", command),
+                command: format!("{command:?}"),
                 code: output.status.code(),
                 stdout: String::from_utf8_lossy(&output.stdout).to_string(),
                 stderr: String::from_utf8_lossy(&output.stderr).to_string(),

--- a/crates/augurs-seasons/src/periodogram.rs
+++ b/crates/augurs-seasons/src/periodogram.rs
@@ -252,8 +252,7 @@ mod test {
                     .map(|x| x.period)
                     .collect_vec(),
                 *expected,
-                "Test case {}",
-                i
+                "Test case {i}"
             );
         }
     }

--- a/crates/pyaugurs/src/dtw.rs
+++ b/crates/pyaugurs/src/dtw.rs
@@ -88,8 +88,7 @@ impl FromStr for DistanceFn {
             "euclidean" => Ok(DistanceFn::Euclidean),
             "manhattan" => Ok(DistanceFn::Manhattan),
             _ => Err(PyValueError::new_err(format!(
-                "Invalid distance function: {}",
-                s
+                "Invalid distance function: {s}",
             ))),
         }
     }

--- a/examples/clustering/examples/dbscan_clustering.rs
+++ b/examples/clustering/examples/dbscan_clustering.rs
@@ -53,7 +53,7 @@ fn main() {
 
     // Run DBSCAN clustering on the distance matrix.
     let clusters = DbscanClusterer::new(epsilon, min_cluster_size).fit(&distance_matrix);
-    println!("Clusters: {:?}", clusters);
+    println!("Clusters: {clusters:?}");
     assert_eq!(
         clusters,
         vec![

--- a/examples/forecasting/examples/prophet_forecaster.rs
+++ b/examples/forecasting/examples/prophet_forecaster.rs
@@ -40,12 +40,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let predictions = forecaster.predict_in_sample(0.95)?;
     assert_eq!(predictions.point.len(), y.len());
     assert!(predictions.intervals.is_some());
-    println!("In-sample predictions: {:?}", predictions);
+    println!("In-sample predictions: {predictions:?}");
 
     // Generate 10 out-of-sample predictions with 95% prediction intervals.
     let predictions = forecaster.predict(10, 0.95)?;
     assert_eq!(predictions.point.len(), 10);
     assert!(predictions.intervals.is_some());
-    println!("Out-of-sample predictions: {:?}", predictions);
+    println!("Out-of-sample predictions: {predictions:?}");
     Ok(())
 }

--- a/js/augurs-prophet-js/src/lib.rs
+++ b/js/augurs-prophet-js/src/lib.rs
@@ -82,7 +82,7 @@ impl augurs_prophet::Optimizer for JsOptimizer {
         let result = self
             .func
             .call3(&this, &init, &data_s, &opts)
-            .map_err(|x| augurs_prophet::optimizer::Error::string(format!("{:?}", x)))?;
+            .map_err(|x| augurs_prophet::optimizer::Error::string(format!("{x:?}")))?;
         let result: OptimizeOutput = serde_wasm_bindgen::from_value(result)
             .map_err(augurs_prophet::optimizer::Error::custom)?;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated string and error message formatting across multiple modules to use Rust's modern inline named formatting syntax for improved clarity and consistency in output and error reporting messages. No changes to application logic or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->