### PR TITLE
chore: bump and patch various dependencies for rand 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,11 +48,12 @@ argmin = "0.10.0"
 bytemuck = "1.18.0"
 chrono = "0.4.38"
 distrs = "0.2.1"
-getrandom = { version = "0.2.10", features = ["js"] }
+getrandom = "0.3"
 itertools = "0.14.0"
 js-sys = "0.3.64"
 num-traits = "0.2.19"
-rand = "0.8.5"
+rand = "0.9.0"
+rand_distr = "0.5.1"
 roots = "0.0.8"
 serde = { version = "1.0.166", features = ["derive"] }
 statrs = "0.18.0"
@@ -64,6 +65,11 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", default-features = false }
 tsify-next = { version = "0.5.3", default-features = false, features = ["js"] }
 wasm-bindgen = "0.2.99"
+wasmtime = "38"
+wasmtime-wasi = "38"
+wasmtime-wasi-io = "38"
+wit-bindgen = "0.46.0"
+wit-component = "0.239.0"
 
 assert_approx_eq = "1.1.0"
 criterion = "0.7.0"
@@ -88,3 +94,14 @@ lto = false
 [profile.profiling]
 inherits = "release"
 debug = true
+
+[patch.crates-io]
+argmin = { git = "https://github.com/argmin-rs/argmin", branch = "main" }
+argmin-math = { git = "https://github.com/argmin-rs/argmin", branch = "main" }
+cap-rand = { git = "https://github.com/sd2k/cap-std", branch = "bump-rand" }
+changepoint = { git = "https://github.com/sd2k/changepoint", branch = "patched-deps-to-bump-rand" }
+rv = { git = "https://github.com/sd2k/rv", branch = "bump-rand-dependency" }
+statrs = { git = "https://github.com/RobertJacobsonCDC/statrs", branch = "update_rand_to_09" }
+wasmtime = { git = "https://github.com/sd2k/wasmtime", branch = "bump-rand" }
+wasmtime-wasi = { git = "https://github.com/sd2k/wasmtime", branch = "bump-rand" }
+wasmtime-wasi-io = { git = "https://github.com/sd2k/wasmtime", branch = "bump-rand" }

--- a/crates/augurs-changepoint/src/lib.rs
+++ b/crates/augurs-changepoint/src/lib.rs
@@ -8,7 +8,7 @@ use changepoint::{
         process::gaussian::kernel::{
             AddKernel, ConstantKernel, Kernel, ProductKernel, RBFKernel, WhiteKernel,
         },
-        traits::{ConjugatePrior, HasSuffStat, Rv},
+        traits::{ConjugatePrior, HasDensity, HasSuffStat, Rv},
     },
     utils::map_changepoints,
     Argpcp, BocpdLike, BocpdTruncated,
@@ -32,7 +32,7 @@ pub trait Detector {
 pub struct BocpdDetector<Dist, Prior>
 where
     Dist: Rv<f64> + HasSuffStat<f64>,
-    Prior: ConjugatePrior<f64, Dist> + Clone,
+    Prior: ConjugatePrior<f64, Dist> + HasDensity<Dist> + Clone,
     Dist::Stat: Clone + fmt::Debug,
 {
     detector: BocpdTruncated<f64, Dist, Prior>,
@@ -41,7 +41,7 @@ where
 impl<Dist, Prior> Detector for BocpdDetector<Dist, Prior>
 where
     Dist: Rv<f64> + HasSuffStat<f64>,
-    Prior: ConjugatePrior<f64, Dist, Posterior = Prior> + Clone,
+    Prior: ConjugatePrior<f64, Dist, Posterior = Prior> + HasDensity<Dist> + Clone,
     Dist::Stat: Clone + fmt::Debug,
 {
     fn detect_changepoints(&mut self, y: &[f64]) -> Vec<usize> {

--- a/crates/augurs-ets/Cargo.toml
+++ b/crates/augurs-ets/Cargo.toml
@@ -17,7 +17,7 @@ itertools.workspace = true
 lstsq = "0.7.0"
 nalgebra = "0.34.0"
 rand.workspace = true
-rand_distr = "0.4.3"
+rand_distr.workspace = true
 roots.workspace = true
 serde = { workspace = true, optional = true, features = ["derive"] }
 thiserror.workspace = true

--- a/crates/augurs-ets/src/model.rs
+++ b/crates/augurs-ets/src/model.rs
@@ -1464,7 +1464,7 @@ impl Forecast<'_> {
             params.gamma
         };
         let phi = if params.phi.is_nan() { 0.0 } else { params.phi };
-        let rng = &mut rand::thread_rng();
+        let rng = &mut rand::rng();
         let normal = Normal::new(0.0, fit.sigma_squared().sqrt()).unwrap();
         // Use the same `f` vector for each simulation to avoid re-allocating.
         // For some reason statsforecast uses a length of 10 for `f`?

--- a/crates/augurs-outlier/Cargo.toml
+++ b/crates/augurs-outlier/Cargo.toml
@@ -16,7 +16,6 @@ bench = false
 itertools.workspace = true
 rayon = { version = "1.10.0", optional = true }
 roots.workspace = true
-rand.workspace = true
 rustc-hash = "2.0.0"
 rv = { version = "0.18.0", default-features = false }
 serde = { workspace = true, features = ["derive"], optional = true }
@@ -26,6 +25,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 augurs.workspace = true
+rand.workspace = true
 serde_json.workspace = true
 
 [features]

--- a/crates/augurs-prophet/Cargo.toml
+++ b/crates/augurs-prophet/Cargo.toml
@@ -32,6 +32,7 @@ augurs-core.workspace = true
 bytemuck = { workspace = true, features = ["derive"], optional = true }
 itertools.workspace = true
 rand.workspace = true
+rand_distr.workspace = true
 statrs.workspace = true
 serde = { workspace = true, optional = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
@@ -39,12 +40,12 @@ tempfile = { version = "3.13.0", optional = true }
 thiserror.workspace = true
 tracing.workspace = true
 ureq = { version = "3.0.0", optional = true }
-wasmtime = { version = "36", features = [
+wasmtime = { workspace = true, features = [
     "runtime",
     "component-model",
 ], optional = true }
-wasmtime-wasi = { version = "36", optional = true }
-wasmtime-wasi-io = { version = "36", optional = true }
+wasmtime-wasi = { workspace = true, optional = true }
+wasmtime-wasi-io = { workspace = true, optional = true }
 zip = { version = "5", optional = true }
 
 [dev-dependencies]

--- a/crates/augurs-prophet/src/cmdstan.rs
+++ b/crates/augurs-prophet/src/cmdstan.rs
@@ -55,7 +55,7 @@ use std::{
     time::Duration,
 };
 
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 
 use crate::{optimizer, Optimizer, PositiveFloat, TryFromFloatError};
 
@@ -526,8 +526,8 @@ impl OptimizeCommand<'_> {
         command.arg(format!(
             "seed={}",
             self.opts.seed.unwrap_or_else(|| {
-                let mut rng = thread_rng();
-                rng.gen_range(1..99999)
+                let mut rng = rng();
+                rng.random_range(1..99999)
             })
         ));
         command.arg("data");

--- a/js/augurs-changepoint-js/Cargo.toml
+++ b/js/augurs-changepoint-js/Cargo.toml
@@ -20,7 +20,7 @@ test = false
 [dependencies]
 augurs-core-js.workspace = true
 augurs-changepoint = { workspace = true, features = ["serde"] }
-getrandom = { version = "0.2.10", features = ["js"] }
+getrandom = { version = "0.3", features = ["wasm_js"] }
 js-sys = "0.3.64"
 serde.workspace = true
 serde-wasm-bindgen = "0.6.0"


### PR DESCRIPTION
This commit is an attempt to remove rand 0.8 from the dependency tree
and replace it with rand 0.9, and by extension getrandom 0.3.

Right now it has a lot of patched dependencies, which I'm using as
a todo-list to know where I need to contribute various patches upstream.
