### PR TITLE
chore: bump and patch various dependencies for rand 0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,12 +96,21 @@ inherits = "release"
 debug = true
 
 [patch.crates-io]
+# rand 0.9 merged into main, waiting for a new release.
 argmin = { git = "https://github.com/argmin-rs/argmin", branch = "main" }
 argmin-math = { git = "https://github.com/argmin-rs/argmin", branch = "main" }
-cap-rand = { git = "https://github.com/sd2k/cap-std", branch = "bump-rand" }
+
+# Depends on rv PR and release (see below).
 changepoint = { git = "https://github.com/sd2k/changepoint", branch = "patched-deps-to-bump-rand" }
+# See PR at https://github.com/promised-ai/rv/pull/48.
 rv = { git = "https://github.com/sd2k/rv", branch = "bump-rand-dependency" }
+
+# See PR at https://github.com/statrs-dev/statrs/pull/331.
 statrs = { git = "https://github.com/RobertJacobsonCDC/statrs", branch = "update_rand_to_09" }
+
+# Depends on cap-rand PR/release (see below).
 wasmtime = { git = "https://github.com/sd2k/wasmtime", branch = "bump-rand" }
 wasmtime-wasi = { git = "https://github.com/sd2k/wasmtime", branch = "bump-rand" }
 wasmtime-wasi-io = { git = "https://github.com/sd2k/wasmtime", branch = "bump-rand" }
+# See PR at https://github.com/bytecodealliance/cap-std/pull/394
+cap-rand = { git = "https://github.com/sd2k/cap-std", branch = "bump-rand" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,15 +44,16 @@ augurs-testing = { path = "crates/augurs-testing" }
 augurs-core-js = { path = "js/augurs-core-js" }
 
 anyhow = "1.0.89"
-argmin = "0.10.0"
+argmin = "0.11.0"
 bytemuck = "1.18.0"
 chrono = "0.4.38"
 distrs = "0.2.1"
-getrandom = { version = "0.2.10", features = ["js"] }
+getrandom = "0.3"
 itertools = "0.14.0"
 js-sys = "0.3.64"
 num-traits = "0.2.19"
-rand = "0.8.5"
+rand = "0.9.0"
+rand_distr = "0.5.1"
 roots = "0.0.8"
 serde = { version = "1.0.166", features = ["derive"] }
 statrs = "0.18.0"
@@ -64,6 +65,11 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", default-features = false }
 tsify-next = { version = "0.5.3", default-features = false, features = ["js"] }
 wasm-bindgen = "0.2.99"
+wasmtime = "38"
+wasmtime-wasi = "38"
+wasmtime-wasi-io = "38"
+wit-bindgen = "0.46.0"
+wit-component = "0.239.0"
 
 assert_approx_eq = "1.1.0"
 criterion = "0.7.0"
@@ -88,3 +94,14 @@ lto = false
 [profile.profiling]
 inherits = "release"
 debug = true
+
+[patch.crates-io]
+argmin = { git = "https://github.com/argmin-rs/argmin", branch = "main" }
+argmin-math = { git = "https://github.com/argmin-rs/argmin", branch = "main" }
+cap-rand = { git = "https://github.com/sd2k/cap-std", branch = "bump-rand" }
+changepoint = { git = "https://github.com/sd2k/changepoint", branch = "patched-deps-to-bump-rand" }
+rv = { git = "https://github.com/sd2k/rv", branch = "bump-rand-dependency" }
+statrs = { git = "https://github.com/RobertJacobsonCDC/statrs", branch = "update_rand_to_09" }
+wasmtime = { git = "https://github.com/sd2k/wasmtime", branch = "bump-rand" }
+wasmtime-wasi = { git = "https://github.com/sd2k/wasmtime", branch = "bump-rand" }
+wasmtime-wasi-io = { git = "https://github.com/sd2k/wasmtime", branch = "bump-rand" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ augurs-core-js = { path = "js/augurs-core-js" }
 anyhow = "1.0.89"
 argmin = "0.11.0"
 bytemuck = "1.18.0"
+changepoint = "0.15.0"
 chrono = "0.4.38"
 distrs = "0.2.1"
 getrandom = "0.3"
@@ -55,6 +56,7 @@ num-traits = "0.2.19"
 rand = "0.9.0"
 rand_distr = "0.5.1"
 roots = "0.0.8"
+rv = { version = "0.19.0", default-features = false }
 serde = { version = "1.0.166", features = ["derive"] }
 statrs = "0.18.0"
 serde_json = "1.0.128"
@@ -96,15 +98,6 @@ inherits = "release"
 debug = true
 
 [patch.crates-io]
-# rand 0.9 merged into main, waiting for a new release.
-argmin = { git = "https://github.com/argmin-rs/argmin", branch = "main" }
-argmin-math = { git = "https://github.com/argmin-rs/argmin", branch = "main" }
-
-# Depends on rv PR and release (see below).
-changepoint = { git = "https://github.com/sd2k/changepoint", branch = "patched-deps-to-bump-rand" }
-# See PR at https://github.com/promised-ai/rv/pull/48.
-rv = { git = "https://github.com/sd2k/rv", branch = "bump-rand-dependency" }
-
 # See PR at https://github.com/statrs-dev/statrs/pull/331.
 statrs = { git = "https://github.com/RobertJacobsonCDC/statrs", branch = "update_rand_to_09" }
 

--- a/crates/augurs-changepoint/Cargo.toml
+++ b/crates/augurs-changepoint/Cargo.toml
@@ -17,7 +17,7 @@ bench = false
 
 [dependencies]
 augurs-core.workspace = true
-changepoint = "0.14.1"
+changepoint.workspace = true
 distrs.workspace = true
 itertools.workspace = true
 serde = { workspace = true, optional = true, features = ["derive"] }

--- a/crates/augurs-changepoint/src/lib.rs
+++ b/crates/augurs-changepoint/src/lib.rs
@@ -8,7 +8,7 @@ use changepoint::{
         process::gaussian::kernel::{
             AddKernel, ConstantKernel, Kernel, ProductKernel, RBFKernel, WhiteKernel,
         },
-        traits::{ConjugatePrior, HasSuffStat, Rv},
+        traits::{ConjugatePrior, HasDensity, HasSuffStat, Rv},
     },
     utils::map_changepoints,
     Argpcp, BocpdLike, BocpdTruncated,
@@ -32,7 +32,7 @@ pub trait Detector {
 pub struct BocpdDetector<Dist, Prior>
 where
     Dist: Rv<f64> + HasSuffStat<f64>,
-    Prior: ConjugatePrior<f64, Dist> + Clone,
+    Prior: ConjugatePrior<f64, Dist> + HasDensity<Dist> + Clone,
     Dist::Stat: Clone + fmt::Debug,
 {
     detector: BocpdTruncated<f64, Dist, Prior>,
@@ -41,7 +41,7 @@ where
 impl<Dist, Prior> Detector for BocpdDetector<Dist, Prior>
 where
     Dist: Rv<f64> + HasSuffStat<f64>,
-    Prior: ConjugatePrior<f64, Dist, Posterior = Prior> + Clone,
+    Prior: ConjugatePrior<f64, Dist, Posterior = Prior> + HasDensity<Dist> + Clone,
     Dist::Stat: Clone + fmt::Debug,
 {
     fn detect_changepoints(&mut self, y: &[f64]) -> Vec<usize> {

--- a/crates/augurs-ets/Cargo.toml
+++ b/crates/augurs-ets/Cargo.toml
@@ -17,7 +17,7 @@ itertools.workspace = true
 lstsq = "0.7.0"
 nalgebra = "0.34.0"
 rand.workspace = true
-rand_distr = "0.4.3"
+rand_distr.workspace = true
 roots.workspace = true
 serde = { workspace = true, optional = true, features = ["derive"] }
 thiserror.workspace = true

--- a/crates/augurs-ets/src/model.rs
+++ b/crates/augurs-ets/src/model.rs
@@ -1464,7 +1464,7 @@ impl Forecast<'_> {
             params.gamma
         };
         let phi = if params.phi.is_nan() { 0.0 } else { params.phi };
-        let rng = &mut rand::thread_rng();
+        let rng = &mut rand::rng();
         let normal = Normal::new(0.0, fit.sigma_squared().sqrt()).unwrap();
         // Use the same `f` vector for each simulation to avoid re-allocating.
         // For some reason statsforecast uses a length of 10 for `f`?

--- a/crates/augurs-outlier/Cargo.toml
+++ b/crates/augurs-outlier/Cargo.toml
@@ -17,7 +17,7 @@ itertools.workspace = true
 rayon = { version = "1.10.0", optional = true }
 roots.workspace = true
 rustc-hash = "2.0.0"
-rv = { version = "0.18.0", default-features = false }
+rv.workspace = true
 serde = { workspace = true, features = ["derive"], optional = true }
 thiserror.workspace = true
 tinyvec = { workspace = true, features = ["std"] }

--- a/crates/augurs-outlier/Cargo.toml
+++ b/crates/augurs-outlier/Cargo.toml
@@ -16,7 +16,6 @@ bench = false
 itertools.workspace = true
 rayon = { version = "1.10.0", optional = true }
 roots.workspace = true
-rand.workspace = true
 rustc-hash = "2.0.0"
 rv = { version = "0.18.0", default-features = false }
 serde = { workspace = true, features = ["derive"], optional = true }
@@ -26,6 +25,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 augurs.workspace = true
+rand.workspace = true
 serde_json.workspace = true
 
 [features]

--- a/crates/augurs-outlier/src/mad.rs
+++ b/crates/augurs-outlier/src/mad.rs
@@ -524,7 +524,7 @@ mod test {
     ];
 
     fn gen_multi_modal_data() -> Vec<f64> {
-        let mut rng = rand::thread_rng();
+        let mut rng = rand::rng();
         let lower = rv::dist::Uniform::new_unchecked(0., 100.).sample(100, &mut rng);
         let upper = rv::dist::Uniform::new_unchecked(1000., 1100.).sample(100, &mut rng);
         lower.into_iter().interleave(upper).collect()

--- a/crates/augurs-prophet/Cargo.toml
+++ b/crates/augurs-prophet/Cargo.toml
@@ -32,6 +32,7 @@ augurs-core.workspace = true
 bytemuck = { workspace = true, features = ["derive"], optional = true }
 itertools.workspace = true
 rand.workspace = true
+rand_distr.workspace = true
 statrs.workspace = true
 serde = { workspace = true, optional = true, features = ["derive"] }
 serde_json = { workspace = true, optional = true }
@@ -39,12 +40,12 @@ tempfile = { version = "3.13.0", optional = true }
 thiserror.workspace = true
 tracing.workspace = true
 ureq = { version = "3.0.0", optional = true }
-wasmtime = { version = "36", features = [
+wasmtime = { workspace = true, features = [
     "runtime",
     "component-model",
 ], optional = true }
-wasmtime-wasi = { version = "36", optional = true }
-wasmtime-wasi-io = { version = "36", optional = true }
+wasmtime-wasi = { workspace = true, optional = true }
+wasmtime-wasi-io = { workspace = true, optional = true }
 zip = { version = "5", optional = true }
 
 [dev-dependencies]

--- a/crates/augurs-prophet/src/cmdstan.rs
+++ b/crates/augurs-prophet/src/cmdstan.rs
@@ -55,7 +55,7 @@ use std::{
     time::Duration,
 };
 
-use rand::{thread_rng, Rng};
+use rand::{rng, Rng};
 
 use crate::{optimizer, Optimizer, PositiveFloat, TryFromFloatError};
 
@@ -526,8 +526,8 @@ impl OptimizeCommand<'_> {
         command.arg(format!(
             "seed={}",
             self.opts.seed.unwrap_or_else(|| {
-                let mut rng = thread_rng();
-                rng.gen_range(1..99999)
+                let mut rng = rng();
+                rng.random_range(1..99999)
             })
         ));
         command.arg("data");

--- a/js/augurs-changepoint-js/Cargo.toml
+++ b/js/augurs-changepoint-js/Cargo.toml
@@ -20,7 +20,7 @@ test = false
 [dependencies]
 augurs-core-js.workspace = true
 augurs-changepoint = { workspace = true, features = ["serde"] }
-getrandom = { version = "0.2.10", features = ["js"] }
+getrandom = { workspace = true, features = ["wasm_js"] }
 js-sys = "0.3.64"
 serde.workspace = true
 serde-wasm-bindgen = "0.6.0"

--- a/js/augurs-clustering-js/Cargo.toml
+++ b/js/augurs-clustering-js/Cargo.toml
@@ -20,7 +20,7 @@ test = false
 [dependencies]
 augurs-core-js.workspace = true
 augurs-clustering.workspace = true
-getrandom.workspace = true
+getrandom = { workspace = true, features = ["wasm_js"] }
 js-sys.workspace = true
 serde.workspace = true
 serde-wasm-bindgen.workspace = true

--- a/js/augurs-ets-js/Cargo.toml
+++ b/js/augurs-ets-js/Cargo.toml
@@ -21,7 +21,7 @@ test = false
 augurs-core.workspace = true
 augurs-core-js.workspace = true
 augurs-ets.workspace = true
-getrandom.workspace = true
+getrandom = { workspace = true, features = ["wasm_js"] }
 serde.workspace = true
 serde-wasm-bindgen.workspace = true
 tsify-next.workspace = true

--- a/js/augurs-mstl-js/Cargo.toml
+++ b/js/augurs-mstl-js/Cargo.toml
@@ -22,7 +22,7 @@ augurs-core-js.workspace = true
 augurs-ets = { workspace = true, features = ["mstl"] }
 augurs-forecaster.workspace = true
 augurs-mstl.workspace = true
-getrandom.workspace = true
+getrandom = { version = "0.3", features = ["wasm_js"] }
 serde.workspace = true
 serde-wasm-bindgen.workspace = true
 tsify-next.workspace = true

--- a/js/augurs-outlier-js/Cargo.toml
+++ b/js/augurs-outlier-js/Cargo.toml
@@ -20,7 +20,7 @@ test = false
 [dependencies]
 augurs-core-js.workspace = true
 augurs-outlier = { workspace = true, features = ["serde"] }
-getrandom.workspace = true
+getrandom = { workspace = true, features = ["wasm_js"] }
 serde.workspace = true
 serde-wasm-bindgen.workspace = true
 tsify-next.workspace = true

--- a/js/augurs-prophet-js/Cargo.toml
+++ b/js/augurs-prophet-js/Cargo.toml
@@ -20,7 +20,7 @@ test = false
 [dependencies]
 augurs-core-js.workspace = true
 augurs-prophet = { workspace = true, features = ["serde"] }
-getrandom.workspace = true
+getrandom = { workspace = true, features = ["wasm_js"] }
 js-sys.workspace = true
 serde.workspace = true
 serde_json = "1"

--- a/js/augurs-transforms-js/Cargo.toml
+++ b/js/augurs-transforms-js/Cargo.toml
@@ -21,7 +21,7 @@ test = false
 argmin = { workspace = true, features = ["wasm-bindgen"] }
 augurs-core-js.workspace = true
 augurs-forecaster.workspace = true
-getrandom.workspace = true
+getrandom = { workspace = true, features = ["wasm_js"] }
 serde.workspace = true
 serde-wasm-bindgen.workspace = true
 tsify-next.workspace = true

--- a/js/justfile
+++ b/js/justfile
@@ -15,7 +15,7 @@ build: \
 build-inner target args='':
   cd augurs-{{target}}-js && \
     rm -rf ./pkg && \
-    wasm-pack build \
+    RUSTFLAGS='--cfg getrandom_backend="wasm_js"' wasm-pack build \
       --scope bsull \
       --out-name {{target}} \
       --release \
@@ -44,4 +44,3 @@ test:
 publish:
   cd augurs && \
     npm publish --access public
-


### PR DESCRIPTION
This commit is an attempt to remove rand 0.8 from the dependency tree
and replace it with rand 0.9, and by extension getrandom 0.3.

Right now it has a lot of patched dependencies, which I'm using as
a todo-list to know where I need to contribute various patches upstream.
