### PR TITLE
fix: assert that data is rectangular in DBSCAN preprocessing

### DIFF
--- a/crates/augurs-outlier/src/dbscan.rs
+++ b/crates/augurs-outlier/src/dbscan.rs
@@ -363,15 +363,47 @@ impl Data {
     }
 
     /// Create a `Data` struct from column-major data.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `data` is empty or if all columns do not have the same length.
+    /// Use [`try_from_column_major`](Self::try_from_column_major) for a fallible version.
     #[instrument(skip(data))]
     pub fn from_column_major(data: &[&[f64]]) -> Self {
+        Self::try_from_column_major(data).expect("all columns in data must have the same length")
+    }
+
+    /// Try to create a `Data` struct from column-major data.
+    ///
+    /// Returns an error if `data` is empty or if all columns do not have the same length.
+    #[instrument(skip(data))]
+    pub fn try_from_column_major(data: &[&[f64]]) -> Result<Self, Error> {
+        if data.is_empty() {
+            return Err(Error::Preprocessing(
+                Box::<dyn std::error::Error>::from("data must not be empty").into(),
+            ));
+        }
+
+        let n_series = data[0].len();
+
+        // Validate that all columns have the same length (skip first column since it's our reference).
+        for (i, col) in data.iter().enumerate().skip(1) {
+            if col.len() != n_series {
+                return Err(Error::Preprocessing(
+                    Box::<dyn std::error::Error>::from(format!(
+                        "all columns must have the same length: column 0 has {} elements, but column {} has {} elements",
+                        n_series, i, col.len()
+                    ))
+                    .into(),
+                ));
+            }
+        }
+
         let mut sorted = Vec::with_capacity(data.len());
-        let mut n_series = 0;
         for ts in data {
             sorted.push(SortedData::new(ts.to_vec()));
-            n_series = n_series.max(ts.len());
         }
-        Self { sorted, n_series }
+        Ok(Self { sorted, n_series })
     }
 
     /// Calculate the span of the data: the difference between the highest and lowest values.
@@ -750,6 +782,44 @@ mod tests {
     fn test_from_row_major_rectangular_data_succeeds() {
         let data: &[&[f64]] = &[&[1.0, 2.0, 3.0], &[4.0, 5.0, 6.0], &[7.0, 8.0, 9.0]];
         let result = Data::try_from_row_major(data);
+        assert!(result.is_ok());
+        let data_struct = result.unwrap();
+        assert_eq!(data_struct.n_series, 3);
+    }
+
+    #[test]
+    fn test_try_from_column_major_empty_data() {
+        let data: &[&[f64]] = &[];
+        let result = Data::try_from_column_major(data);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("data must not be empty"));
+    }
+
+    #[test]
+    fn test_try_from_column_major_non_rectangular_data() {
+        let data: &[&[f64]] = &[&[1.0, 2.0, 3.0], &[4.0, 5.0], &[7.0, 8.0, 9.0]];
+        let result = Data::try_from_column_major(data);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("all columns must have the same length"));
+        assert!(err.contains("column 0 has 3 elements"));
+        assert!(err.contains("column 1 has 2 elements"));
+    }
+
+    #[test]
+    #[should_panic(expected = "all columns in data must have the same length")]
+    fn test_from_column_major_panics_on_non_rectangular_data() {
+        let data: &[&[f64]] = &[&[1.0, 2.0, 3.0], &[4.0, 5.0]];
+        Data::from_column_major(data);
+    }
+
+    #[test]
+    fn test_from_column_major_rectangular_data_succeeds() {
+        let data: &[&[f64]] = &[&[1.0, 2.0, 3.0], &[4.0, 5.0, 6.0], &[7.0, 8.0, 9.0]];
+        let result = Data::try_from_column_major(data);
         assert!(result.is_ok());
         let data_struct = result.unwrap();
         assert_eq!(data_struct.n_series, 3);

--- a/crates/augurs-outlier/src/dbscan.rs
+++ b/crates/augurs-outlier/src/dbscan.rs
@@ -53,7 +53,7 @@ pub struct DbscanDetector {
 impl OutlierDetector for DbscanDetector {
     type PreprocessedData = Data;
     fn preprocess(&self, y: &[&[f64]]) -> Result<Self::PreprocessedData, Error> {
-        Ok(Data::from_row_major(y))
+        Data::try_from_row_major(y)
     }
 
     fn detect(&self, y: &Self::PreprocessedData) -> Result<OutlierOutput, Error> {
@@ -312,29 +312,54 @@ pub struct Data {
 
 impl Data {
     /// Create a `Data` struct from row-major data.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `data` is empty or if all rows do not have the same length.
+    /// Use [`try_from_row_major`](Self::try_from_row_major) for a fallible version.
     #[instrument(skip(data))]
     pub fn from_row_major(data: &[&[f64]]) -> Self {
+        Self::try_from_row_major(data).expect("all rows in data must have the same length")
+    }
+
+    /// Try to create a `Data` struct from row-major data.
+    ///
+    /// Returns an error if `data` is empty or if all rows do not have the same length.
+    #[instrument(skip(data))]
+    pub fn try_from_row_major(data: &[&[f64]]) -> Result<Self, Error> {
+        if data.is_empty() {
+            return Err(Error::Preprocessing(
+                Box::<dyn std::error::Error>::from("data must not be empty").into(),
+            ));
+        }
+
         let n_series = data.len();
         let n_timestamps = data[0].len();
-        // First transpose the data.
+
+        // Validate that all rows have the same length (skip first row since it's our reference).
+        for (i, row) in data.iter().enumerate().skip(1) {
+            if row.len() != n_timestamps {
+                return Err(Error::Preprocessing(
+                    Box::<dyn std::error::Error>::from(format!(
+                        "all rows must have the same length: row 0 has {} elements, but row {} has {} elements",
+                        n_timestamps, i, row.len()
+                    ))
+                    .into(),
+                ));
+            }
+        }
+
+        // Transpose the data.
         let mut transposed = vec![vec![f64::NAN; n_series]; n_timestamps];
         data.iter().enumerate().for_each(|(i, chunk)| {
             chunk.iter().enumerate().for_each(|(j, value)| {
                 transposed[j][i] = *value;
             })
         });
-        // Check that the transposition worked.
-        debug_assert_eq!(transposed.len(), n_timestamps);
-        #[cfg(debug_assertions)]
-        transposed.iter().for_each(|row| {
-            debug_assert_eq!(row.len(), n_series);
-        });
-        transposed.iter().for_each(|row| {
-            debug_assert_eq!(row.len(), n_series);
-        });
+
         // Then sort values at each timestamp.
         let sorted = transposed.into_iter().map(SortedData::new).collect();
-        Self { sorted, n_series }
+        Ok(Self { sorted, n_series })
     }
 
     /// Create a `Data` struct from column-major data.
@@ -690,5 +715,43 @@ mod tests {
         let processed = dbscan.preprocess(data).unwrap();
         let results = dbscan.detect(&processed).unwrap();
         assert!(results.cluster_band.is_none());
+    }
+
+    #[test]
+    fn test_try_from_row_major_empty_data() {
+        let data: &[&[f64]] = &[];
+        let result = Data::try_from_row_major(data);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("data must not be empty"));
+    }
+
+    #[test]
+    fn test_try_from_row_major_non_rectangular_data() {
+        let data: &[&[f64]] = &[&[1.0, 2.0, 3.0], &[4.0, 5.0], &[7.0, 8.0, 9.0]];
+        let result = Data::try_from_row_major(data);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("all rows must have the same length"));
+        assert!(err.contains("row 0 has 3 elements"));
+        assert!(err.contains("row 1 has 2 elements"));
+    }
+
+    #[test]
+    #[should_panic(expected = "all rows in data must have the same length")]
+    fn test_from_row_major_panics_on_non_rectangular_data() {
+        let data: &[&[f64]] = &[&[1.0, 2.0, 3.0], &[4.0, 5.0]];
+        Data::from_row_major(data);
+    }
+
+    #[test]
+    fn test_from_row_major_rectangular_data_succeeds() {
+        let data: &[&[f64]] = &[&[1.0, 2.0, 3.0], &[4.0, 5.0, 6.0], &[7.0, 8.0, 9.0]];
+        let result = Data::try_from_row_major(data);
+        assert!(result.is_ok());
+        let data_struct = result.unwrap();
+        assert_eq!(data_struct.n_series, 3);
     }
 }


### PR DESCRIPTION
Prior to this commit, the DBSCAN preprocessing step would panic with a
confusing error messages during transposition if the data was not
rectangular. This was hard to debug because it didn't mention the
expected shape of the data.

This commit adds a check that the data is rectangular and panics if it
is not. It also adds tests to ensure that the check is performed.

It also adds a fallible version of the preprocessing step that returns
an error if the data is not rectangular.

Relates to #362.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fallible constructors for loading row-major and column-major datasets with input validation; existing constructors now delegate to them.

* **Bug Fixes**
  * Rejects empty or non-rectangular datasets early to avoid downstream crashes; preserves prior panicking behavior for the old constructors.

* **Tests**
  * Expanded tests covering empty/non-rectangular errors and successful loading for both row- and column-major inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->