### PR TITLE
ci: disable setup-node caching in JS release workflow

### DIFF
--- a/.github/workflows/js-release.yml
+++ b/.github/workflows/js-release.yml
@@ -62,6 +62,8 @@ jobs:
         with:
           node-version-file: js/.node-version
           registry-url: "https://registry.npmjs.org"
+          # Disable caching in this release workflow to avoid cache poisoning.
+          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci
@@ -105,6 +107,8 @@ jobs:
         with:
           node-version-file: js/.node-version
           registry-url: "https://registry.npmjs.org"
+          # Disable caching in this release workflow to avoid cache poisoning.
+          package-manager-cache: false
 
       - name: Publish to npm
         working-directory: package


### PR DESCRIPTION
## Summary

Fixes the two `cache-poisoning` (high severity) findings zizmor reports in `.github/workflows/js-release.yml`.

Both `actions/setup-node` steps enable package-manager caching by default. In a release/publish workflow, an attacker who can poison that cache could compromise the published npm artifact. Per the [zizmor cache-poisoning audit](https://docs.zizmor.sh/audits/#cache-poisoning), the remediation is to disable caching in release workflows.

## Changes

- Set `package-manager-cache: false` on both `actions/setup-node` steps (build-and-test and publish jobs).

## Verification

```
$ zizmor ./.github/workflows/js-release.yml
No findings to report. Good job! (2 suppressed)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)