### PR TITLE
docs: document signed commit requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,3 +9,16 @@ The book is built using [mdbook][]; you will need to install it first.
 From the `book` directory, run `mdbook serve` to serve the book at http://localhost:3000.
 
 [mdbook]: https://rust-lang.github.io/mdBook/guide/installation.html
+
+## Submit a pull request
+
+Effective 2026-06-22, all Grafana Labs repositories [require signed commits][signed-commits].
+To learn more about Git commit verification, refer to [About commit signature verification][signing-commits]
+and [Checking your commit signature verification status][verifying-commits].
+
+> [!NOTE]
+> Pull requests containing any unsigned commits cannot be merged until all commits are signed.
+
+[signed-commits]: https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-signed-commits
+[signing-commits]: https://docs.github.com/authentication/managing-commit-signature-verification/about-commit-signature-verification
+[verifying-commits]: https://docs.github.com/authentication/troubleshooting-commit-signature-verification/checking-your-commit-and-tag-signature-verification-status


### PR DESCRIPTION
Add the Grafana Labs signed-commit requirement to the contributor documentation.\n\nThis mirrors grafana/docker-otel-lgtm#1599.\n\nDocumentation-only change; no tests are required.