### PR TITLE
fix(transforms): stabilise the forward Yeo-Johnson transform near lambda 0 and 2

### DIFF
--- a/crates/augurs-forecaster/src/transforms/power.rs
+++ b/crates/augurs-forecaster/src/transforms/power.rs
@@ -234,6 +234,10 @@ impl Transformer for BoxCox {
 }
 
 /// Returns the Yeo-Johnson transformation of the given value.
+///
+/// Uses `ln_1p`/`exp_m1` forms away from the exact log branches so values near
+/// `lambda == 0` or `lambda == 2` do not collapse through cancellation, mirroring
+/// [`inverse_yeo_johnson`].
 fn yeo_johnson(x: f64, lambda: f64) -> Result<f64, Error> {
     if x.is_nan() {
         return Ok(x);
@@ -244,14 +248,16 @@ fn yeo_johnson(x: f64, lambda: f64) -> Result<f64, Error> {
 
     if x >= 0.0 {
         if lambda == 0.0 {
-            Ok((x + 1.0).ln())
+            Ok(x.ln_1p())
         } else {
-            Ok(((x + 1.0).powf(lambda) - 1.0) / lambda)
+            Ok((lambda * x.ln_1p()).exp_m1() / lambda)
         }
     } else if lambda == 2.0 {
-        Ok(-(-x + 1.0).ln())
+        Ok(-(-x).ln_1p())
     } else {
-        Ok(-((-x + 1.0).powf(2.0 - lambda) - 1.0) / (2.0 - lambda))
+        let two_minus_lambda = 2.0 - lambda;
+        let scaled = (two_minus_lambda * (-x).ln_1p()).exp_m1();
+        Ok(-scaled / two_minus_lambda)
     }
 }
 
@@ -278,17 +284,15 @@ fn inverse_yeo_johnson(y: f64, lambda: f64) -> Result<f64, Error> {
                 Ok((lambda_y.ln_1p() / lambda).exp_m1())
             }
         }
+    } else if lambda == 2.0 {
+        Ok(-(-y).exp_m1())
     } else {
         let two_minus_lambda = 2.0 - lambda;
-        if two_minus_lambda == 0.0 {
-            Ok(-(-y).exp_m1())
+        let scaled_y = -two_minus_lambda * y;
+        if scaled_y <= -1.0 {
+            Err(Error::InvalidDomain)
         } else {
-            let scaled_y = -two_minus_lambda * y;
-            if scaled_y <= -1.0 {
-                Err(Error::InvalidDomain)
-            } else {
-                Ok(-(scaled_y.ln_1p() / two_minus_lambda).exp_m1())
-            }
+            Ok(-(scaled_y.ln_1p() / two_minus_lambda).exp_m1())
         }
     }
 }
@@ -657,6 +661,64 @@ mod test {
             (near_zero - log_limit).abs() < 1e-12,
             "near-zero lambda inverse collapsed: got {near_zero}, limit {log_limit}",
         );
+    }
+
+    #[test]
+    fn inverse_yeo_johnson_near_two_lambda_uses_stable_limit() {
+        // Mirror of `inverse_yeo_johnson_near_zero_lambda_uses_stable_limit`
+        // for the negative branch, where `2 - lambda` plays the role of
+        // `lambda`.
+        let y = -1e-4;
+        let near_two = inverse_yeo_johnson(y, 2.0 - 1e-12).unwrap();
+        let log_limit = -(-y).exp_m1();
+        assert!(
+            (near_two - log_limit).abs() < 1e-12,
+            "near-two lambda inverse collapsed: got {near_two}, limit {log_limit}",
+        );
+    }
+
+    #[test]
+    fn yeo_johnson_near_degenerate_lambda_uses_stable_limit() {
+        // The forward transform has the same conditioning problem as the
+        // inverse: `((x + 1)^lambda - 1) / lambda` cancels to exactly zero once
+        // `lambda * ln(x + 1)` drops below the f64 epsilon, so the direct power
+        // form returned 0.0 for every input at small lambda.
+        let x = 1e-4;
+        let near_zero = yeo_johnson(x, 1e-12).unwrap();
+        let log_limit = x.ln_1p();
+        assert!(
+            (near_zero - log_limit).abs() < 1e-12,
+            "near-zero lambda forward collapsed: got {near_zero}, limit {log_limit}",
+        );
+
+        let near_two = yeo_johnson(-x, 2.0 - 1e-12).unwrap();
+        let log_limit = -x.ln_1p();
+        assert!(
+            (near_two - log_limit).abs() < 1e-12,
+            "near-two lambda forward collapsed: got {near_two}, limit {log_limit}",
+        );
+    }
+
+    #[test]
+    fn yeo_johnson_round_trip_near_degenerate_lambda() {
+        // With both halves using `ln_1p`/`exp_m1` the round trip holds even for
+        // lambda a whisker away from the log branches, which the direct power
+        // forms could not do in either direction. Brent's tolerance is around
+        // `sqrt(f64::EPSILON)`, so a fitted lambda this close to 0 or 2 is
+        // reachable in practice.
+        let lambdas = [1e-12, -1e-12, 2.0 - 1e-12, 2.0 + 1e-12];
+        let xs = [-100.0, -1.0, -1e-4, 1e-4, 1.0, 100.0];
+        for &lambda in &lambdas {
+            for &x in &xs {
+                let y = yeo_johnson(x, lambda).unwrap();
+                let round_tripped = inverse_yeo_johnson(y, lambda).unwrap();
+                let rel = (round_tripped - x).abs() / x.abs();
+                assert!(
+                    rel < 1e-12,
+                    "round-trip failed for lambda={lambda}, x={x}: got {round_tripped} (rel {rel})",
+                );
+            }
+        }
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #528, covering the two non-blocking items from that review.

## The forward half was still the unstable one

#528 rewrote `inverse_yeo_johnson` in `ln_1p`/`exp_m1` form so it no longer collapses for λ close to the log branches, but left `yeo_johnson` on the direct power form. `((x + 1)^λ - 1) / λ` cancels to exactly zero once `λ * ln(x + 1)` falls below the f64 epsilon, so the round trip was still broken — just from the other direction:

| λ | x | round trip (before) | rel err |
|---|---|---|---|
| 1e-12 | 1e-4 | `0.0` (forward returns exactly 0.0) | 1.0 |
| 1e-12 | 1.0 | 1.00015… | 1.5e-4 |
| 1e-9 | 1e-4 | 9.9925e-5 | 7.5e-4 |

Brent's tolerance is around `sqrt(f64::EPSILON)`, so a fitted λ this close to 0 or 2 is reachable in practice, and the existing `yeo_johnson_inverse_round_trip` test doesn't cover it — it only samples λ on a 0.5 grid.

The fix applies the same treatment to the forward: `expm1(λ * ln1p(x)) / λ` on the positive branch, and the `2 - λ` mirror on the negative one.

### Accuracy

Checked against 60-digit `Decimal` references. The new form is within 1 ulp on every case tested; the power form was out by up to 100%:

```
x=1e-4   λ=1e-12    new rel=0        old rel=1.00e0
x=1.0    λ=1e-12    new rel=0        old rel=1.10e-4
x=100    λ=1e-15    new rel=1.9e-16  old rel=1.04e-2
x=-1.0   λ=2-1e-12  new rel=0        old rel=2.09e-5
x=-100   λ=2+1e-12  new rel=0        old rel=1.35e-7
x=1.0    λ=0.5      new rel=0        old rel=2.7e-16
```

Over a λ ∈ [-4, 4] × x ∈ [-50, 50] grid the old and new forms agree to **3.4e-15** relative, so output for ordinary λ is unchanged.

## Mirror test for the negative branch

`inverse_yeo_johnson_near_zero_lambda_uses_stable_limit` pins the positive branch near λ=0; `inverse_yeo_johnson_near_two_lambda_uses_stable_limit` does the same for the negative branch near λ=2, which has the identical failure profile (the power form returns 0.0 there too).

## Also

Swapped the inverse's `two_minus_lambda == 0.0` test for `lambda == 2.0`. The two are equivalent for all f64, but the latter mirrors the forward's branch test literally, which was the point of #528.

## Verification

- `yeo_johnson_near_degenerate_lambda_uses_stable_limit` and `yeo_johnson_round_trip_near_degenerate_lambda` both fail without the forward change (confirmed by reverting the implementation and keeping the tests).
- `cargo test -p augurs-forecaster` → 64 + 5 pass; `cargo test --workspace --all-features` fully green.
- `cargo clippy -p augurs-forecaster --all-targets -- -D warnings` and `cargo fmt --check` clean.

## Not included

`BoxCox` has the same two gaps flagged in the #528 review — `inverse_transform` has no `NotFitted` guard (the `Transformer` trait doc says it should), and `box_cox`/`inverse_box_cox` share the near-zero-λ conditioning issue. Left out to keep this diff to one transform; happy to file an issue or do it in a second PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)