### PR TITLE
ci: pass Vault secrets explicitly to steps that need them

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -190,6 +190,11 @@ jobs:
 
       - name: Publish to PyPI
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        env:
+          # get-vault-secrets v2 no longer exports secrets as environment
+          # variables, so they must be passed explicitly to the steps needing
+          # them. See https://github.com/grafana/shared-workflows/releases/tag/get-vault-secrets%2Fv2.0.0
+          MATURIN_PYPI_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).MATURIN_PYPI_TOKEN }}
         with:
           command: upload
           args: --non-interactive --skip-existing wheels-*/*

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -38,6 +38,12 @@ jobs:
 
       - name: Run release-plz
         uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
+        env:
+          # get-vault-secrets v2 no longer exports secrets as environment
+          # variables, so they must be passed explicitly to the steps needing
+          # them. See https://github.com/grafana/shared-workflows/releases/tag/get-vault-secrets%2Fv2.0.0
+          CARGO_REGISTRY_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).CARGO_REGISTRY_TOKEN }}
+          GITHUB_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_TOKEN }}
         with:
           command: release
 
@@ -74,5 +80,11 @@ jobs:
 
       - name: Run release-plz
         uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
+        env:
+          # get-vault-secrets v2 no longer exports secrets as environment
+          # variables, so they must be passed explicitly to the steps needing
+          # them. See https://github.com/grafana/shared-workflows/releases/tag/get-vault-secrets%2Fv2.0.0
+          CARGO_REGISTRY_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).CARGO_REGISTRY_TOKEN }}
+          GITHUB_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_TOKEN }}
         with:
           command: release-pr


### PR DESCRIPTION
## Why

`Release-plz` has been failing on `main` since June. There are two independent causes:

1. **Since 2026-06-16** (`6d8a8d0`): the GitHub token stored in Vault at `ci/repo/grafana/augurs/github:token` started returning `gh: Bad credentials (HTTP 401)` in the `release-plz/git-config` step — it looks like the token expired. **This PR does not fix that**; the token needs rotating (or, better, replacing with a short-lived GitHub App token) separately.

2. **Since 2026-07-08** (#519, `18a94c8`): dependabot bumped `grafana/shared-workflows/actions/get-vault-secrets` from `v1.3.2` to `v2.0.0`, a breaking major that [removed the `export_env` option and always uses JSON output](https://github.com/grafana/shared-workflows/releases/tag/get-vault-secrets%2Fv2.0.0). Secrets are no longer exported as environment variables, so `release-plz` now fails before it even reaches the token:

   ```
   Error: environment variable GITHUB_TOKEN is undefined
   ```

   You can see the change in the logs — the June run passes `exportEnv: true` to `vault-action` and the release-plz step's env contains `GITHUB_TOKEN: ***`; the [2026-08-21 run](https://github.com/grafana/augurs/actions/runs/32462276914) passes `exportEnv: false` and the step env has only the `CARGO_*` variables.

## What

Read the secrets from the action's JSON output and pass them via `env:` on just the steps that need them, which is the migration path the v2 README prescribes:

- `release-plz.yml`: `GITHUB_TOKEN` and `CARGO_REGISTRY_TOKEN` on both `Run release-plz` steps.
- `python.yml`: `MATURIN_PYPI_TOKEN` on `Publish to PyPI`. This job has the same latent breakage but only runs on `pyaugurs-*` tags, so it hasn't failed yet — it would have broken the next Python release.

Scoping secrets to individual steps rather than the whole job is also the reason for the upstream breaking change, so this is a slight security improvement over the old behaviour.

`actionlint` is clean on both files.

## Note on OIDC

The Vault fetch already uses OIDC — it's the *GitHub* token inside Vault that's a long-lived credential. Swapping it for `grafana/shared-workflows/actions/create-github-app-token` would only change where `GITHUB_TOKEN` comes from, not this wiring, so that can land as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)