### PR TITLE
ci: mint a GitHub App token for release-plz instead of using a PAT

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -34,16 +34,23 @@ jobs:
           # Secrets placed in the ci/repo/grafana/augurs/<path> path in Vault
           repo_secrets: |
             CARGO_REGISTRY_TOKEN=crates-io:api-token
-            GITHUB_TOKEN=github:token
+
+      # TODO: replace `github_app` with the real App name once it exists; see
+      # https://github.com/grafana/augurs/issues/536. Until then this workflow
+      # will fail to mint a token.
+      - id: get-github-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
+        with:
+          github_app: augurs-release
 
       - name: Run release-plz
         uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
         env:
-          # get-vault-secrets v2 no longer exports secrets as environment
-          # variables, so they must be passed explicitly to the steps needing
-          # them. See https://github.com/grafana/shared-workflows/releases/tag/get-vault-secrets%2Fv2.0.0
+          # Neither get-vault-secrets nor create-github-app-token export their
+          # secrets as environment variables, so they must be passed explicitly
+          # to the steps needing them.
           CARGO_REGISTRY_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).CARGO_REGISTRY_TOKEN }}
-          GITHUB_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get-github-token.outputs.token }}
         with:
           command: release
 
@@ -76,15 +83,22 @@ jobs:
           # Secrets placed in the ci/repo/grafana/augurs/<path> path in Vault
           repo_secrets: |
             CARGO_REGISTRY_TOKEN=crates-io:api-token
-            GITHUB_TOKEN=github:token
+
+      # TODO: replace `github_app` with the real App name once it exists; see
+      # https://github.com/grafana/augurs/issues/536. Until then this workflow
+      # will fail to mint a token.
+      - id: get-github-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@46f48da11e78ebdba7a8747ae456b11062fac83e # create-github-app-token/v0.3.1
+        with:
+          github_app: augurs-release
 
       - name: Run release-plz
         uses: release-plz/action@e8792575c7f2366cf6ff3ccc33ead9ace5b691c7 # v0.5.130
         env:
-          # get-vault-secrets v2 no longer exports secrets as environment
-          # variables, so they must be passed explicitly to the steps needing
-          # them. See https://github.com/grafana/shared-workflows/releases/tag/get-vault-secrets%2Fv2.0.0
+          # Neither get-vault-secrets nor create-github-app-token export their
+          # secrets as environment variables, so they must be passed explicitly
+          # to the steps needing them.
           CARGO_REGISTRY_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).CARGO_REGISTRY_TOKEN }}
-          GITHUB_TOKEN: ${{ fromJSON(steps.get-secrets.outputs.secrets).GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.get-github-token.outputs.token }}
         with:
           command: release-pr


### PR DESCRIPTION
Tracked by #536. **Draft — cannot be merged as-is**, see blockers below.

Stacked on #535; rebase onto `main` once that lands. The diff shown here is against `fix/vault-secrets-env-wiring`, so it contains only the credential change.

## What

Replace the static PAT at `ci/repo/grafana/augurs/github:token` with an ephemeral GitHub App installation token from `grafana/shared-workflows/actions/create-github-app-token`, which authenticates to Vault over the same OIDC flow `get-vault-secrets` already uses. That PAT expired around 2026-06-16 (`gh: Bad credentials (HTTP 401)`), and we've moved away from PATs org-wide, so rotating it isn't the answer.

`CARGO_REGISTRY_TOKEN` stays in Vault via `get-vault-secrets` — crates.io has no App-token equivalent — so both jobs keep that step, just with one fewer secret in it.

Both jobs already declare `id-token: write`, which is all `create-github-app-token` needs, so no permission changes.

## Blockers

- [ ] **The GitHub App doesn't exist yet.** `github_app: augurs-release` is a placeholder and must be replaced with the real name; there's a `TODO` on both steps pointing at #536. As written this workflow will fail to mint a token.
- [ ] The App needs `contents: write` and `pull_requests: write`, installed on `grafana/augurs`, and registering with Vault. If it's set up with a non-`default` permission set, add `permission_set:` to both steps.

## Why an App token rather than the default `GITHUB_TOKEN`

release-plz opens the release PR, and PRs opened with the default `GITHUB_TOKEN` cannot trigger other workflows — CI would never run on the release PR. An App installation token isn't subject to that, which is why a PAT was used in the first place.

## Verification

`Release-plz` only triggers on push to `main`, so this can't be proven green from a PR — the first push to `main` after merge is the real test. `actionlint` is clean and the YAML parses to the expected values, which is as far as static checking goes here.

Once this merges and a run is green, `ci/repo/grafana/augurs/github:token` can be deleted from Vault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)