### PR TITLE
fix(security/augurs-prophet): update wasmtime crates to v48

### DIFF
--- a/crates/augurs-prophet/Cargo.toml
+++ b/crates/augurs-prophet/Cargo.toml
@@ -39,12 +39,12 @@ tempfile = { version = "3.13.0", optional = true }
 thiserror.workspace = true
 tracing.workspace = true
 ureq = { version = "3.0.0", optional = true }
-wasmtime = { version = "42.0.2", features = [
+wasmtime = { version = "48", features = [
     "runtime",
     "component-model",
 ], optional = true }
-wasmtime-wasi = { version = "42.0.2", optional = true }
-wasmtime-wasi-io = { version = "42.0.2", optional = true }
+wasmtime-wasi = { version = "48", optional = true }
+wasmtime-wasi-io = { version = "48", optional = true }
 zip = { version = "8", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Bumps `wasmtime`, `wasmtime-wasi`, and `wasmtime-wasi-io` in `augurs-prophet` from **42** to **48** in lockstep, resolving both security advisories Renovate flagged:

- #508 — `wasmtime` to v46 (medium) [security]
- #509 — `wasmtime-wasi` to v45 (high) [security]

## Why one PR instead of two

These three crates must share the same major version. Renovate raised the advisories as separate PRs each bumping a single crate, which cannot compile — e.g. `wasmtime` 46 against `wasmtime-wasi` 42 fails with `add_to_linker_sync` / `IoView::table` type-mismatch errors. Bumping all three together to the latest common release (48.0.0) satisfies both advisories and, as it happens, needs **no source changes** — the earlier CI failures were purely the version mismatch.

**Supersedes #508 and #509** (close both once this merges).

## Testing

All run locally with `--all-features` (matching CI):

- `cargo check --all-targets --all-features` ✅
- `just test-all` → 180/180 pass (incl. `wasmstan`, `wasmstan_nans`) ✅
- `cargo clippy --all-features --all-targets -- -D warnings` ✅
- doctests ✅

Note: wasmtime 48 raises the effective MSRV to Rust 1.95; CI builds on stable (currently 1.98) so this is fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)