### PR TITLE
fix(security/pyaugurs): update pyo3 to 0.29 and numpy to 0.29

### DIFF
--- a/crates/pyaugurs/Cargo.toml
+++ b/crates/pyaugurs/Cargo.toml
@@ -26,8 +26,8 @@ augurs-ets = { workspace = true, features = ["mstl"] }
 augurs-forecaster.workspace = true
 augurs-mstl.workspace = true
 augurs-seasons.workspace = true
-numpy = "0.28.0"
-pyo3 = { version = "0.28.2", features = ["extension-module"] }
+numpy = "0.29.0"
+pyo3 = { version = "0.29.2", features = ["extension-module"] }
 tracing = { version = "0.1.37", features = ["log"] }
 
 [lints]


### PR DESCRIPTION
## Summary

Bumps `pyo3` from **0.28.2 → 0.29.2** in `pyaugurs`, resolving the security advisory Renovate flagged in #515, and bumps `numpy` (rust-numpy) from **0.28 → 0.29** to match.

## Why one PR instead of Renovate's

`rust-numpy` is released in lockstep with `pyo3` and must share its minor version (numpy 0.29 ↔ pyo3 0.29). Renovate's #515 bumped `pyo3` alone, which can't build against numpy 0.28. Bumping both together resolves the advisory and needs **no source changes**.

**Supersedes #515** (auto-closes once this merges).

## Testing

Replicated the CI Python flow locally:

- `cargo check -p pyaugurs` ✅
- `cargo clippy -p pyaugurs --all-targets -- -D warnings` ✅
- `maturin develop --uv` (builds the extension module) ✅
- `pytest crates/pyaugurs/tests` → **120 passed** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)