### PR TITLE
fix(deps): update nalgebra to 0.35 and lstsq to 0.8 in augurs-ets

### DIFF
--- a/crates/augurs-ets/Cargo.toml
+++ b/crates/augurs-ets/Cargo.toml
@@ -14,8 +14,8 @@ augurs-core.workspace = true
 augurs-mstl = { workspace = true, optional = true }
 distrs.workspace = true
 itertools.workspace = true
-lstsq = "0.7.0"
-nalgebra = "0.34.0"
+lstsq = "0.8.0"
+nalgebra = "0.35.0"
 rand.workspace = true
 rand_distr = "0.4.3"
 roots.workspace = true


### PR DESCRIPTION
## Summary

Bumps `nalgebra` **0.34 → 0.35** in `augurs-ets`, unblocking Renovate's #510, and bumps `lstsq` **0.7 → 0.8** to match.

## Why #510 was stuck

#510 bumped `nalgebra` alone. It failed because the pinned `lstsq 0.7` depends on `nalgebra 0.34`, and 0.35's matrix types are incompatible with lstsq's `lstsq(&X, &y, eps)` call (E0308: arguments to this function are incorrect).

`lstsq 0.8.0` — published after #510 was opened — depends on `nalgebra ^0.35`. Bumping both together resolves the conflict. lstsq's public API (`lstsq::lstsq(&X, &y, eps)` returning `.solution`) is unchanged, so **no source changes** are required.

**Supersedes #510** (auto-closes once this merges).

## Testing

Ran CI's exact commands locally:

- `cargo check --all-targets --all-features` ✅
- `just test-all` → **180/180** (incl. `augurs-ets model::test::initial_params`, which exercises the lstsq path, and the air-passengers forecast tests) ✅
- `cargo clippy --all-features --all-targets -- -D warnings` ✅
- doctests ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)